### PR TITLE
Implement (rois, info) tuple return pattern

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMBoxer"
 uuid = "a7d3b33b-b840-4f8e-b556-99be03134090"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Pkg.add(url="https://github.com/JuliaSMLM/SMLMBoxer.jl")
 ```
 
 ## Usage
-The main function provided by the package is `getboxes()`, which detects particles or blobs in a multidimensional image stack and returns an `ROIBatch` containing detected regions centered around local maxima. The function uses a Difference of Gaussians (DoG) filter optimized for blob detection and is capable of GPU acceleration.
+The main function provided by the package is `getboxes()`, which detects particles or blobs in a multidimensional image stack and returns a tuple `(ROIBatch, BoxesInfo)` containing detected regions centered around local maxima and execution metadata. The function uses a Difference of Gaussians (DoG) filter optimized for blob detection and is capable of GPU acceleration.
 
 ### Example (Recommended - PSF-Aware Detection)
 ```julia
@@ -32,10 +32,13 @@ using SMLMBoxer, SMLMData
 camera = IdealCamera(1:256, 1:256, 0.1f0)  # 256×256 pixels, 100nm pixel size
 
 # Detect with PSF-aware parameters (physical units)
-roi_batch = getboxes(imagestack, camera;
+(rois, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,              # PSF sigma in microns (physical units)
     min_photons = 500.0,           # Minimum photon count to detect
     boxsize = 11)                  # ROI size in pixels
+
+# Check execution info
+println("Backend: $(info.backend), Time: $(info.elapsed_ns / 1e6) ms")
 ```
 
 ### Primary Parameters (PSF-Aware Interface)
@@ -67,13 +70,20 @@ For expert users who want direct control over the DoG filter:
 - `on_wait::Function`: Optional callback for wait progress reporting.
 
 ### Returns
-`ROIBatch` object with the following fields:
+A tuple `(rois, info)` where:
+
+`rois::ROIBatch` with the following fields:
 - `data`: ROI stack (boxsize × boxsize × n_rois) containing detected image patches.
 - `x_corners`: Vector of x (column) corner positions in camera coordinates.
 - `y_corners`: Vector of y (row) corner positions in camera coordinates.
 - `frame_indices`: Vector of frame indices for each ROI.
 - `camera`: Camera object for coordinate system tracking.
 - `roi_size`: Size of each ROI.
+
+`info::BoxesInfo` with the following fields:
+- `backend`: Compute backend used (`:gpu` or `:cpu`).
+- `elapsed_ns`: Wall time in nanoseconds.
+- `device_id`: GPU device ID used (-1 for CPU).
 
 ### How It Works
 The `getboxes()` function applies a Difference of Gaussians (DoG) filter to identify blob-like features. When using the PSF-aware interface, the filter scales are automatically matched to your PSF width for optimal detection sensitivity, and the photon threshold is converted to the appropriate intensity threshold accounting for PSF spreading and filter response.

--- a/api_overview.md
+++ b/api_overview.md
@@ -4,8 +4,9 @@ Particle/blob detection in SMLM image stacks using difference-of-Gaussians filte
 
 ## Exports
 
-**Total exports:** 4
-- `getboxes` - Main detection function
+**Total exports:** 5
+- `getboxes` - Main detection function, returns `(ROIBatch, BoxesInfo)` tuple
+- `BoxesInfo` - Execution metadata struct (backend, timing, device)
 - `recommend_batch_size` - Memory-aware batch sizing utility
 - `ROIBatch` - Re-exported from SMLMData.jl
 - `SingleROI` - Re-exported from SMLMData.jl
@@ -41,7 +42,7 @@ When `SCMOSCamera` is provided, implements SMITE-style inverse variance weightin
 
 ## Core Function
 
-### `getboxes(imagestack, camera=nothing; kwargs...) -> ROIBatch`
+### `getboxes(imagestack, camera=nothing; kwargs...) -> (ROIBatch, BoxesInfo)`
 
 Main detection function. Applies DoG filtering, finds local maxima, extracts ROI patches.
 
@@ -69,13 +70,29 @@ Main detection function. Applies DoG filtering, finds local maxima, extracts ROI
 - `gpu_timeout::Real` - Max seconds to wait in `:gpu` mode (default: Inf)
 - `on_wait::Function` - Optional callback `(elapsed, available, required) -> nothing` for wait progress
 
-**Returns:** `ROIBatch` with fields:
+**Returns:** Tuple `(rois, info)` where:
+
+`rois::ROIBatch` with fields:
 - `data` - ROI stack (boxsize × boxsize × n_rois)
 - `x_corners` - Vector of x (column) corner positions
 - `y_corners` - Vector of y (row) corner positions
 - `frame_indices` - Vector of frame indices for each ROI
 - `camera` - Camera object (provided or default IdealCamera)
 - `roi_size` - Size of each ROI (square)
+
+`info::BoxesInfo` with fields:
+- `backend` - Compute backend used (`:gpu` or `:cpu`)
+- `elapsed_ns` - Wall time in nanoseconds
+- `device_id` - GPU device ID used (-1 for CPU)
+
+### `BoxesInfo`
+
+Metadata struct returned by `getboxes` containing execution information.
+
+**Fields:**
+- `backend::Symbol` - Compute backend used (`:gpu` or `:cpu`)
+- `elapsed_ns::UInt64` - Wall time in nanoseconds
+- `device_id::Int` - GPU device ID used (-1 for CPU)
 
 ### `recommend_batch_size(height, width; backend=:auto, memory_fraction=0.8) -> Int`
 
@@ -112,7 +129,7 @@ println("Load up to $max_frames frames at a time")
 for chunk_start in 1:max_frames:total_frames
     chunk_end = min(chunk_start + max_frames - 1, total_frames)
     imagestack = load_frames(chunk_start:chunk_end)
-    roi_batch = getboxes(imagestack, camera; psf_sigma=0.13)
+    (rois, info) = getboxes(imagestack, camera; psf_sigma=0.13)
     # ... process results
 end
 ```
@@ -146,17 +163,20 @@ using SMLMBoxer, SMLMData
 camera = IdealCamera(1:256, 1:256, 0.1f0)
 
 # Detect particles with PSF-aware thresholding
-roi_batch = getboxes(imagestack, camera;
+(rois, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,        # 130nm PSF in microns
     min_photons = 500.0,     # Minimum 500 photons
     boxsize = 11)
 
 # Access results
-n_detections = length(roi_batch.x_corners)
-boxes = roi_batch.data              # 11×11×n ROI patches
-positions_x = roi_batch.x_corners   # Column positions
-positions_y = roi_batch.y_corners   # Row positions
-frames = roi_batch.frame_indices
+n_detections = length(rois.x_corners)
+boxes = rois.data              # 11×11×n ROI patches
+positions_x = rois.x_corners   # Column positions
+positions_y = rois.y_corners   # Row positions
+frames = rois.frame_indices
+
+# Check execution info
+println("Backend: $(info.backend), Time: $(info.elapsed_ns / 1e6) ms")
 ```
 
 ### sCMOS Variance-Weighted Detection
@@ -168,16 +188,19 @@ readnoise_map = Float32.(load_readnoise_calibration("camera_calib.mat"))
 camera = SCMOSCamera(256, 256, 0.1f0, readnoise_map)
 
 # Variance-weighted detection (automatically enabled)
-roi_batch = getboxes(imagestack, camera;
+(rois, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,
     min_photons = 300.0,  # Lower threshold possible with noise weighting
     backend = :auto)      # GPU with CPU fallback
+
+# Verify backend used
+println("Used $(info.backend) backend")
 ```
 
 ### Advanced: Direct Parameter Control
 ```julia
 # Expert mode: bypass PSF-aware interface
-roi_batch = getboxes(imagestack;
+(rois, info) = getboxes(imagestack;
     sigma_small = 1.5,   # Custom filter sigma (pixels)
     sigma_large = 3.0,
     minval = 10.0,       # Direct intensity threshold
@@ -187,21 +210,21 @@ roi_batch = getboxes(imagestack;
 
 ### Processing Individual ROIs
 ```julia
-roi_batch = getboxes(imagestack, camera; psf_sigma=0.13)
+(rois, info) = getboxes(imagestack, camera; psf_sigma=0.13)
 
 # Iterate over ROIs
-for roi in roi_batch
+for roi in rois
     # SingleROI fields:
     # - roi.data: Image patch
     # - roi.corner: (x, y) corner position
     # - roi.frame_idx: Frame index
     # - roi.camera: Camera ROI calibration
-    
+
     fit_gaussian(roi.data)
 end
 
 # Direct indexing
-first_roi = roi_batch[1]
+first_roi = rois[1]
 ```
 
 ## Internal Functions (Not Exported)

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -40,7 +40,7 @@ imagestack = gen_images(smld, psf, poisson_noise=true, bg=10.0)
 
 ```julia
 # Detect using recommended PSF-aware interface
-roi_batch = getboxes(Float32.(imagestack), camera;
+(rois, info) = getboxes(Float32.(imagestack), camera;
     psf_sigma = 0.13,      # PSF sigma in microns
     min_photons = 500.0,   # Detection threshold
     boxsize = 11,          # ROI size
@@ -48,8 +48,9 @@ roi_batch = getboxes(Float32.(imagestack), camera;
 
 # Check results
 println("Ground truth: $(length(emitters)) emitters")
-println("Detected: $(length(roi_batch)) ROIs")
-println("Detection rate: $(length(roi_batch)/length(emitters)*100)%")
+println("Detected: $(length(rois)) ROIs")
+println("Detection rate: $(length(rois)/length(emitters)*100)%")
+println("Backend: $(info.backend), Time: $(info.elapsed_ns / 1e6) ms")
 ```
 
 ### Accessing Detection Results
@@ -58,13 +59,13 @@ println("Detection rate: $(length(roi_batch)/length(emitters)*100)%")
 # ROIBatch provides multiple access patterns
 
 # 1. Direct field access
-boxes = roi_batch.data              # (boxsize × boxsize × n_rois)
-x_positions = roi_batch.x_corners   # x (column) corners
-y_positions = roi_batch.y_corners   # y (row) corners
-frames = roi_batch.frame_indices    # frame numbers
+boxes = rois.data              # (boxsize × boxsize × n_rois)
+x_positions = rois.x_corners   # x (column) corners
+y_positions = rois.y_corners   # y (row) corners
+frames = rois.frame_indices    # frame numbers
 
 # 2. Iteration over SingleROI objects
-for (i, roi) in enumerate(roi_batch)
+for (i, roi) in enumerate(rois)
     println("ROI $i:")
     println("  Corner: ($(roi.corner[1]), $(roi.corner[2]))")
     println("  Frame: $(roi.frame_idx)")
@@ -73,7 +74,7 @@ for (i, roi) in enumerate(roi_batch)
 end
 
 # 3. Array-like indexing
-first_roi = roi_batch[1]  # Returns SingleROI
+first_roi = rois[1]  # Returns SingleROI
 println("First detection at ($(first_roi.corner[1]), $(first_roi.corner[2]))")
 ```
 
@@ -113,11 +114,13 @@ camera = SCMOSCamera(
 imagestack = gen_images(smld, psf, camera_noise=true, bg=10.0)
 
 # Detection automatically uses variance weighting for SCMOSCamera
-roi_batch = getboxes(Float32.(imagestack), camera;
+(rois, info) = getboxes(Float32.(imagestack), camera;
     psf_sigma = 0.13,
     min_photons = 500.0,
     boxsize = 11,
     use_gpu = true)  # GPU acceleration for variance weighting
+
+println("Used $(info.backend) backend")
 
 # Analyze detection uniformity across noise regions
 function count_by_noise_region(batch, n_pixels, split_col)
@@ -133,7 +136,7 @@ function count_by_noise_region(batch, n_pixels, split_col)
     return low_noise, high_noise
 end
 
-low, high = count_by_noise_region(roi_batch, n_pixels, n_pixels÷2)
+low, high = count_by_noise_region(rois, n_pixels, n_pixels÷2)
 println("Low-noise region detections: $low")
 println("High-noise region detections: $high")
 ```
@@ -146,7 +149,7 @@ For expert users who want precise control over filter parameters.
 
 ```julia
 # Direct control over DoG filter sigmas and threshold
-roi_batch = getboxes(imagestack;
+(rois, info) = getboxes(imagestack;
     sigma_small = 1.5,  # Small Gaussian sigma (pixels)
     sigma_large = 3.0,  # Large Gaussian sigma (pixels)
     minval = 15.0,      # DoG intensity threshold
@@ -165,13 +168,13 @@ sigma_values = [1.0, 1.3, 1.5, 2.0]
 results = []
 
 for sigma in sigma_values
-    roi_batch = getboxes(imagestack, camera;
+    (rois, _) = getboxes(imagestack, camera;
         sigma_small = sigma,
         sigma_large = 2.0 * sigma,
         minval = 10.0,
         use_gpu = false)
 
-    push!(results, (sigma=sigma, n_detected=length(roi_batch)))
+    push!(results, (sigma=sigma, n_detected=length(rois)))
 end
 
 # Find optimal sigma
@@ -198,19 +201,23 @@ else
 end
 
 # GPU acceleration enabled by default
-roi_batch_gpu = getboxes(imagestack, camera;
+(rois_gpu, info_gpu) = getboxes(imagestack, camera;
     psf_sigma = 0.13,
     min_photons = 500.0,
     use_gpu = true)  # Automatically uses GPU if available
 
+println("Used $(info_gpu.backend) backend")
+
 # Benchmark GPU vs CPU
 using BenchmarkTools
 
-@time roi_batch_cpu = getboxes(imagestack, camera;
+(rois_cpu, info_cpu) = getboxes(imagestack, camera;
     psf_sigma = 0.13, min_photons = 500.0, use_gpu = false)
+println("CPU time: $(info_cpu.elapsed_ns / 1e6) ms")
 
-@time roi_batch_gpu = getboxes(imagestack, camera;
+(rois_gpu, info_gpu) = getboxes(imagestack, camera;
     psf_sigma = 0.13, min_photons = 500.0, use_gpu = true)
+println("GPU time: $(info_gpu.elapsed_ns / 1e6) ms")
 ```
 
 ### Large Dataset Processing
@@ -220,13 +227,14 @@ using BenchmarkTools
 large_stack = zeros(Float32, 512, 512, 1000)  # 1000 frames
 
 # Automatic batching handles memory constraints
-roi_batch = getboxes(large_stack, camera;
+(rois, info) = getboxes(large_stack, camera;
     psf_sigma = 0.13,
     min_photons = 500.0,
     use_gpu = true)  # Batches frames to fit GPU memory
 
 println("Processed $(size(large_stack, 3)) frames")
-println("Total detections: $(length(roi_batch))")
+println("Total detections: $(length(rois))")
+println("Backend: $(info.backend), Time: $(info.elapsed_ns / 1e9) s")
 ```
 
 ## Integration with Downstream Analysis
@@ -235,14 +243,15 @@ println("Total detections: $(length(roi_batch))")
 
 ```julia
 # ROIBatch integrates directly with SMLMData fitting pipelines
+(rois, info) = getboxes(imagestack, camera; psf_sigma=0.13, min_photons=500.0)
 
 # Example: Filter ROIs by intensity before fitting
 min_intensity = 100.0
-filtered_rois = filter(roi_batch) do roi
+filtered_rois = filter(rois) do roi
     sum(roi.data) > min_intensity
 end
 
-println("Kept $(length(filtered_rois))/$(length(roi_batch)) ROIs")
+println("Kept $(length(filtered_rois))/$(length(rois)) ROIs")
 
 # ROIs maintain coordinate information for fitting
 for roi in filtered_rois
@@ -258,11 +267,11 @@ end
 
 ```julia
 # Convert corner positions to approximate centers
-roi_size = roi_batch.roi_size
+roi_size = rois.roi_size
 center_offset = roi_size ÷ 2
 
-x_centers = roi_batch.x_corners .+ center_offset
-y_centers = roi_batch.y_corners .+ center_offset
+x_centers = rois.x_corners .+ center_offset
+y_centers = rois.y_corners .+ center_offset
 
 # Convert to physical coordinates (microns)
 pixel_size = camera.pixel_edges_x[2] - camera.pixel_edges_x[1]
@@ -281,13 +290,13 @@ println("First detection center: ($(x_microns[1]), $(y_microns[1])) μm")
 n_frames = size(imagestack, 3)
 
 # getboxes processes entire stack and tracks frame indices
-roi_batch = getboxes(imagestack, camera;
+(rois, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,
     min_photons = 500.0)
 
 # Group detections by frame
 using StatsBase
-detections_per_frame = countmap(roi_batch.frame_indices)
+detections_per_frame = countmap(rois.frame_indices)
 
 println("Frame-by-frame detection counts:")
 for frame in sort(collect(keys(detections_per_frame)))
@@ -299,11 +308,11 @@ end
 
 ```julia
 # Filter detections by quality metrics
-function filter_by_quality(roi_batch; min_snr=3.0)
+function filter_by_quality(rois; min_snr=3.0)
     keep_indices = Int[]
 
-    for i in 1:length(roi_batch)
-        roi = roi_batch[i]
+    for i in 1:length(rois)
+        roi = rois[i]
 
         # Calculate simple SNR estimate
         sorted_pixels = sort(vec(roi.data))
@@ -318,12 +327,13 @@ function filter_by_quality(roi_batch; min_snr=3.0)
         end
     end
 
-    return roi_batch[keep_indices]
+    return rois[keep_indices]
 end
 
 # Apply filtering
-high_quality_rois = filter_by_quality(roi_batch, min_snr=5.0)
-println("Kept $(length(high_quality_rois))/$(length(roi_batch)) high-quality ROIs")
+(rois, info) = getboxes(imagestack, camera; psf_sigma=0.13, min_photons=500.0)
+high_quality_rois = filter_by_quality(rois, min_snr=5.0)
+println("Kept $(length(high_quality_rois))/$(length(rois)) high-quality ROIs")
 ```
 
 ### Batch Processing Multiple Files
@@ -338,12 +348,12 @@ for (i, path) in enumerate(file_paths)
     imagestack = load_image_stack(path)
 
     # Detect
-    roi_batch = getboxes(imagestack, camera;
+    (rois, info) = getboxes(imagestack, camera;
         psf_sigma = 0.13,
         min_photons = 500.0)
 
-    println("File $i: $(length(roi_batch)) detections")
-    push!(all_detections, roi_batch)
+    println("File $i: $(length(rois)) detections ($(info.elapsed_ns / 1e6) ms)")
+    push!(all_detections, rois)
 end
 
 # Combine results for aggregate analysis

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -40,19 +40,22 @@ using SMLMBoxer, SMLMData
 camera = IdealCamera(1:256, 1:256, 0.1f0)
 
 # Detect particles using PSF-aware interface
-roi_batch = getboxes(imagestack, camera;
+(rois, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,      # PSF sigma in microns (130 nm)
     min_photons = 500.0,   # Minimum photon count threshold
     boxsize = 11)          # ROI size in pixels
 
 # Access results
-boxes = roi_batch.data              # (11 × 11 × n_rois) array
-x_corners = roi_batch.x_corners     # x (column) positions
-y_corners = roi_batch.y_corners     # y (row) positions
-frames = roi_batch.frame_indices    # frame numbers
+boxes = rois.data              # (11 × 11 × n_rois) array
+x_corners = rois.x_corners     # x (column) positions
+y_corners = rois.y_corners     # y (row) positions
+frames = rois.frame_indices    # frame numbers
+
+# Check execution info
+println("Backend: $(info.backend), Time: $(info.elapsed_ns / 1e6) ms")
 
 # Iterate over detected ROIs
-for roi in roi_batch
+for roi in rois
     # Each roi is a SingleROI with .data, .corner, .frame_idx
     process(roi.data)
 end
@@ -73,10 +76,13 @@ camera = SCMOSCamera(
 )
 
 # Automatically uses variance-weighted filtering
-roi_batch = getboxes(imagestack, camera;
+(rois, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,
     min_photons = 500.0,
     use_gpu = true)     # GPU acceleration for variance weighting
+
+# Verify backend used
+println("Used $(info.backend) backend")
 ```
 
 ## How It Works
@@ -104,7 +110,7 @@ The `getboxes()` function implements a multi-stage blob detection pipeline:
 The recommended interface automatically configures filter parameters from physical units:
 
 ```julia
-roi_batch = getboxes(imagestack, camera;
+(rois, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,      # PSF width in microns (physical units)
     min_photons = 500.0)   # Detection threshold in photons
 ```
@@ -119,7 +125,7 @@ This automatically calculates:
 Expert users can directly control filter parameters:
 
 ```julia
-roi_batch = getboxes(imagestack;
+(rois, info) = getboxes(imagestack;
     sigma_small = 1.5,  # Small Gaussian sigma in pixels
     sigma_large = 3.0,  # Large Gaussian sigma in pixels
     minval = 10.0)      # DoG intensity threshold

--- a/src/SMLMBoxer.jl
+++ b/src/SMLMBoxer.jl
@@ -24,7 +24,7 @@ using Statistics: mean  # For mean gain/QE in threshold calculation
 
 # Re-export ROIBatch and SingleROI from SMLMData for convenience
 using SMLMData: ROIBatch, SingleROI
-export getboxes, ROIBatch, SingleROI, recommend_batch_size
+export getboxes, ROIBatch, SingleROI, recommend_batch_size, BoxesInfo
 
 include("gpu.jl")
 include("types.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,8 +1,8 @@
 """
-    getboxes(imagestack, camera=nothing; kwargs...) -> ROIBatch
+    getboxes(imagestack, camera=nothing; kwargs...) -> (ROIBatch, BoxesInfo)
 
 Detect particles/blobs in a multidimensional image stack and return
-ROI batch with location tracking.
+ROI batch with location tracking and execution metadata.
 
 # Arguments
 - `imagestack::AbstractArray{<:Real}`: The input image stack. Should be 2D or 3D.
@@ -37,13 +37,20 @@ Note: If `psf_sigma` is provided, it overrides sigma_small/sigma_large/minval.
 - `use_gpu::Bool`: DEPRECATED - use `backend` instead. If provided, `true` maps to `:auto`, `false` to `:cpu`.
 
 # Returns
-`ROIBatch` with the following fields:
+A tuple `(rois, info)` where:
+
+`rois::ROIBatch` with the following fields:
 - `data`: ROI stack (boxsize × boxsize × n_rois) containing image patches
 - `x_corners`: Vector of x (column) corner positions in camera coordinates
 - `y_corners`: Vector of y (row) corner positions in camera coordinates
 - `frame_indices`: Vector of frame indices for each ROI
 - `camera`: Camera object (provided or default IdealCamera)
 - `roi_size`: Size of each ROI (square)
+
+`info::BoxesInfo` with the following fields:
+- `backend`: Compute backend used (`:gpu` or `:cpu`)
+- `elapsed_ns`: Wall time in nanoseconds
+- `device_id`: GPU device ID used (-1 for CPU)
 
 # Details on filtering
 
@@ -87,25 +94,28 @@ out around each maximum, excluding overlaps.
 # Recommended: PSF-aware detection with physical units
 camera = IdealCamera(1:256, 1:256, 0.1f0)  # 256×256 pixels, 100nm pixel size
 
-roi_batch = getboxes(imagestack, camera;
+(rois, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,              # PSF sigma in microns (physical units)
     min_photons = 500.0,           # Detect emitters with ≥500 photons
     boxsize = 11)
 
 # Access results
-boxes = roi_batch.data             # (11 × 11 × n_rois)
-x_corners = roi_batch.x_corners    # x (col) positions
-y_corners = roi_batch.y_corners    # y (row) positions
-frames = roi_batch.frame_indices
+boxes = rois.data             # (11 × 11 × n_rois)
+x_corners = rois.x_corners    # x (col) positions
+y_corners = rois.y_corners    # y (row) positions
+frames = rois.frame_indices
+
+# Check execution info
+println("Backend: \$(info.backend), Time: \$(info.elapsed_ns / 1e6) ms")
 
 # Advanced: Direct control over filter parameters
-roi_batch = getboxes(imagestack;
+(rois, info) = getboxes(imagestack;
     sigma_small = 1.5,  # Custom small Gaussian sigma
     sigma_large = 3.0,  # Custom large Gaussian sigma
     minval = 10.0)      # Custom intensity threshold
 
 # Iterate over ROIs
-for roi in roi_batch
+for roi in rois
     # roi is a SingleROI with .data, .corner, .frame_idx
     process(roi.data)
 end
@@ -124,8 +134,10 @@ end
     _getboxes_impl(args::GetBoxesArgs)
 
 Internal implementation of getboxes that does the actual work.
+Returns `(ROIBatch, BoxesInfo)` tuple.
 """
 function _getboxes_impl(args::GetBoxesArgs)
+  t_start = time_ns()
 
   imagestack = reshape_for_flux(args.imagestack)
 
@@ -236,7 +248,13 @@ function _getboxes_impl(args::GetBoxesArgs)
     )
   end
 
-  return ROIBatch(boxstack, x_corners, y_corners, frame_indices, camera)
+  # Capture timing and build info
+  elapsed_ns = time_ns() - t_start
+  backend_used = args.use_gpu ? :gpu : :cpu
+  device_id = args.use_gpu ? Int(CUDA.device().handle) : -1
+  info = BoxesInfo(backend_used, elapsed_ns, device_id)
+
+  return (ROIBatch(boxstack, x_corners, y_corners, frame_indices, camera), info)
 end
 
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,20 @@
 """
+    BoxesInfo
+
+Metadata about `getboxes` execution.
+
+# Fields
+- `backend::Symbol`: Compute backend used (`:gpu` or `:cpu`)
+- `elapsed_ns::UInt64`: Wall time in nanoseconds
+- `device_id::Int`: GPU device ID used (-1 for CPU)
+"""
+struct BoxesInfo
+    backend::Symbol
+    elapsed_ns::UInt64
+    device_id::Int
+end
+
+"""
     get_pixel_size(camera::AbstractCamera)
 
 Extract pixel size from camera pixel edges (in microns).

--- a/test/local_gpu_wait_test.jl
+++ b/test/local_gpu_wait_test.jl
@@ -29,10 +29,10 @@ function run_gpu_wait_tests()
     # Test 1: backend=:cpu should always use CPU
     println("\n[1/6] Testing backend=:cpu...")
     try
-        result = getboxes(img, camera;
+        (result, info) = getboxes(img, camera;
             backend=:cpu,
             sigma_small=1.5, sigma_large=3.0, minval=0.1)
-        println("      Passed: $(length(result)) ROIs detected on CPU")
+        println("      Passed: $(length(result)) ROIs detected on CPU (backend=$(info.backend))")
     catch e
         println("      FAILED: $e")
         all_passed = false
@@ -41,11 +41,11 @@ function run_gpu_wait_tests()
     # Test 2: backend=:auto should work (GPU or CPU fallback)
     println("\n[2/6] Testing backend=:auto...")
     try
-        result = getboxes(img, camera;
+        (result, info) = getboxes(img, camera;
             backend=:auto,
             auto_timeout=5.0,
             sigma_small=1.5, sigma_large=3.0, minval=0.1)
-        println("      Passed: $(length(result)) ROIs detected")
+        println("      Passed: $(length(result)) ROIs detected (backend=$(info.backend))")
     catch e
         println("      FAILED: $e")
         all_passed = false
@@ -61,11 +61,11 @@ function run_gpu_wait_tests()
         # With impossibly short timeout, should either:
         # a) Fall back to CPU with warning (if GPU memory check takes time)
         # b) Still use GPU (if memory was immediately available)
-        result = getboxes(large_img, large_camera;
+        (result, info) = getboxes(large_img, large_camera;
             backend=:auto,
             auto_timeout=0.001,  # Impossibly short
             sigma_small=1.5, sigma_large=3.0, minval=0.1)
-        println("      Passed: $(length(result)) ROIs (GPU memory was immediately available)")
+        println("      Passed: $(length(result)) ROIs (backend=$(info.backend))")
     catch e
         println("      Note: $e")
         all_passed = false
@@ -81,7 +81,7 @@ function run_gpu_wait_tests()
     end
 
     try
-        result = getboxes(img, camera;
+        (result, info) = getboxes(img, camera;
             backend=:auto,
             auto_timeout=2.0,
             on_wait=on_wait_cb,
@@ -100,11 +100,11 @@ function run_gpu_wait_tests()
     if CUDA.functional()
         println("\n[5/6] Testing backend=:gpu (GPU required)...")
         try
-            result = getboxes(img, camera;
+            (result, info) = getboxes(img, camera;
                 backend=:gpu,
                 gpu_timeout=10.0,
                 sigma_small=1.5, sigma_large=3.0, minval=0.1)
-            println("      Passed: $(length(result)) ROIs detected on GPU")
+            println("      Passed: $(length(result)) ROIs detected on GPU (device=$(info.device_id))")
         catch e
             println("      FAILED: $e")
             all_passed = false
@@ -116,10 +116,10 @@ function run_gpu_wait_tests()
     # Test 6: Backwards compatibility with use_gpu kwarg
     println("\n[6/6] Testing backwards compatibility (use_gpu=false)...")
     try
-        result = getboxes(img, camera;
+        (result, info) = getboxes(img, camera;
             use_gpu=false,
             sigma_small=1.5, sigma_large=3.0, minval=0.1)
-        println("      Passed: $(length(result)) ROIs detected (use_gpu=false -> CPU)")
+        println("      Passed: $(length(result)) ROIs detected (use_gpu=false -> backend=$(info.backend))")
     catch e
         println("      FAILED: $e")
         all_passed = false
@@ -196,13 +196,13 @@ function test_memory_pressure_wait()
 
         println("\nRunning getboxes with memory pressure...")
         try
-            result = getboxes(img, camera;
+            (result, info) = getboxes(img, camera;
                 backend=:auto,
                 auto_timeout=3.0,
                 on_wait=on_wait_cb,
                 sigma_small=1.5, sigma_large=3.0, minval=0.1)
 
-            println("Result: $(length(result)) ROIs")
+            println("Result: $(length(result)) ROIs (backend=$(info.backend))")
 
             if wait_triggered[]
                 println("Wait callback WAS triggered - waiting behavior verified!")

--- a/test/local_performance_benchmark.jl
+++ b/test/local_performance_benchmark.jl
@@ -80,7 +80,7 @@ Benchmark getboxes with warmup and multiple runs.
 function benchmark_getboxes(image, camera; use_gpu=false, nwarmup=WARMUP_ITERATIONS, nruns=BENCHMARK_RUNS)
     # Warmup
     for _ in 1:nwarmup
-        result = getboxes(image, camera;
+        (result, _) = getboxes(image, camera;
             boxsize=7,
             overlap=3.0,
             sigma_small=1.0,
@@ -101,7 +101,7 @@ function benchmark_getboxes(image, camera; use_gpu=false, nwarmup=WARMUP_ITERATI
         end
 
         t0 = time()
-        result = getboxes(image, camera;
+        (result, _) = getboxes(image, camera;
             boxsize=7,
             overlap=3.0,
             sigma_small=1.0,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ using Test
         image[30, 60] = 10
 
         # Get boxes without camera (positional interface)
-        roi_batch = getboxes(image;
+        (roi_batch, info) = getboxes(image;
             boxsize=5,
             overlap=3.0,
             sigma_small=1.0,
@@ -30,6 +30,12 @@ using Test
         @test hasfield(typeof(roi_batch), :y_corners)
         @test hasfield(typeof(roi_batch), :frame_indices)
         @test hasfield(typeof(roi_batch), :camera)
+
+        # Test BoxesInfo structure
+        @test info isa BoxesInfo
+        @test info.backend == :cpu
+        @test info.elapsed_ns > 0
+        @test info.device_id == -1
 
         # Should detect two peaks
         @test size(roi_batch.data) == (5, 5, 2)
@@ -54,7 +60,7 @@ using Test
         image[20, 50] = 20
         image[21, 51] = 10
 
-        roi_batch = getboxes(image;
+        (roi_batch, info) = getboxes(image;
             boxsize=5,
             overlap=3.0,
             sigma_small=1.0,
@@ -89,7 +95,7 @@ using Test
         )
 
         # Get boxes with camera
-        roi_batch = getboxes(image, camera;
+        (roi_batch, info) = getboxes(image, camera;
             boxsize=5,
             overlap=3.0,
             sigma_small=1.0,
@@ -135,7 +141,7 @@ using Test
             qe = 0.9f0
         )
 
-        roi_batch = getboxes(image, camera;
+        (roi_batch, info) = getboxes(image, camera;
             boxsize=5,
             overlap=3.0,
             sigma_small=1.0,
@@ -223,7 +229,7 @@ using Test
 
         # Use PSF-aware interface with physical units (microns)
         psf_sigma_microns = 0.13f0  # 130nm PSF
-        roi_batch = getboxes(image, camera;
+        (roi_batch, info) = getboxes(image, camera;
             psf_sigma = psf_sigma_microns,  # In microns (auto-converts to pixels)
             min_photons = 500.0,             # Should detect our 1000 photon peak
             boxsize = 11,
@@ -240,7 +246,7 @@ using Test
         @test roi_batch.y_corners[1] == 45  # y (row)
 
         # Test with higher threshold - should not detect
-        roi_batch_high = getboxes(image, camera;
+        (roi_batch_high, _) = getboxes(image, camera;
             psf_sigma = psf_sigma_microns,
             min_photons = 5000.0,  # Way above our peak
             boxsize = 11,
@@ -254,7 +260,7 @@ using Test
         image = zeros(Float32, 100, 100)
         image[20, 50] = 10
 
-        roi_batch = getboxes(image;
+        (roi_batch, info) = getboxes(image;
             boxsize = 5,
             sigma_small = 1.0,
             sigma_large = 2.0,
@@ -288,7 +294,7 @@ using Test
             qe = 0.9f0
         )
 
-        roi_batch = getboxes(image, camera;
+        (roi_batch, info) = getboxes(image, camera;
             boxsize=7,
             overlap=3.0,
             sigma_small=1.0,


### PR DESCRIPTION
## Summary
- Add `BoxesInfo` struct with execution metadata (`backend`, `elapsed_ns`, `device_id`)
- `getboxes` now returns `(ROIBatch, BoxesInfo)` tuple for consistent API across JuliaSMLM ecosystem
- Export `BoxesInfo` from module

## Changes
- `src/types.jl`: Add `BoxesInfo` struct
- `src/interface.jl`: Capture timing, return tuple from `_getboxes_impl`
- `src/SMLMBoxer.jl`: Export `BoxesInfo`
- `test/runtests.jl`: Update all tests to tuple destructuring
- `test/local_*.jl`: Update benchmark and GPU wait tests
- Documentation: README, api_overview.md, docs/src/*.md

## Test plan
- [x] All 58 unit tests pass
- [x] Local GPU wait tests pass
- [x] Performance benchmarks updated

## Version
0.2.0 -> 0.3.0 (minor bump for API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)