### PR TITLE
Add tuple-pattern, BoxerConfig, CPU batching, and batch tracking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 CUDA = "4, 5"
 KernelAbstractions = "0.9"
 NNlib = "0.9"
-SMLMData = "0.6"
+SMLMData = "0.7"
 cuDNN = "1.4.6"
 julia = "1.9"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SMLMBoxer"
 uuid = "a7d3b33b-b840-4f8e-b556-99be03134090"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -133,13 +133,25 @@ Tuple of `(ROIBatch, BoxesInfo)`:
 ### How It Works
 The `getboxes()` function applies a Difference of Gaussians (DoG) filter to identify blob-like features. When using the PSF-aware interface, the filter scales are automatically matched to your PSF width for optimal detection sensitivity, and the photon threshold is converted to the appropriate intensity threshold accounting for PSF spreading and filter response.
 
-## Additional Tools 
+### GPU Scheduling
 
-In addition to the `getboxes()` function, *SMLMBoxer.jl* provides a number of lower-level tools that can be useful in processing and analyzing image stacks. These are not exported. 
+SMLMBoxer uses a unified GPU retry loop that handles multi-process contention on shared GPU servers:
 
-- `SMLMBoxer.genlocalmaximage(imagestack, kernelsize; minval=0.0, use_gpu=false)`: Generates an image where local maxima in the original image are the only non-zero pixels. 
+1. **NVML polling** scans all GPUs for one with sufficient free memory and low contention (no CUDA context created)
+2. **GPU processing** is attempted: context creation, DoG filtering, local max detection
+3. **On any failure** (no memory, context race, runtime OOM): GPU memory is released via `GC.gc()` + `CUDA.reclaim()`, then re-polls NVML with remaining timeout
+4. **On timeout**: `:auto` falls back to CPU, `:gpu` errors
 
-- `SMLMBoxer.findlocalmax(imagestack, kernelsize; minval=0.0, use_gpu=false)`: Returns the coordinates of local maxima in an image. 
+Memory is always reclaimed after GPU processing (both success and failure) so finished jobs don't block other processes waiting for GPU resources.
 
-- `SMLMBoxer.convolve(imagestack, kernel; use_gpu=false)`: This function convolves an image stack with a given kernel.
+```julia
+# Wait up to 30s for GPU, fall back to CPU
+(roi_batch, info) = getboxes(imagestack, camera;
+    psf_sigma=0.13, backend=:auto, auto_timeout=30.0)
+
+# Monitor wait progress
+(roi_batch, info) = getboxes(imagestack, camera;
+    psf_sigma=0.13, backend=:auto,
+    on_wait=(elapsed, avail, req) -> @info "Waiting..." elapsed avail req)
+```
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ using SMLMBoxer, SMLMData
 camera = IdealCamera(1:256, 1:256, 0.1f0)  # 256×256 pixels, 100nm pixel size
 
 # Detect with PSF-aware parameters (physical units)
-roi_batch = getboxes(imagestack, camera;
+(roi_batch, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,              # PSF sigma in microns (physical units)
     min_photons = 500.0,           # Minimum photon count to detect
     boxsize = 11)                  # ROI size in pixels
+
+# info contains: backend, elapsed_ns, device_id
+println("Processed in ", info.elapsed_ns / 1e6, " ms on ", info.backend)
 ```
 
 ### Primary Parameters (PSF-Aware Interface)
@@ -67,13 +70,20 @@ For expert users who want direct control over the DoG filter:
 - `on_wait::Function`: Optional callback for wait progress reporting.
 
 ### Returns
-`ROIBatch` object with the following fields:
+Tuple of `(ROIBatch, BoxesInfo)`:
+
+**ROIBatch** with the following fields:
 - `data`: ROI stack (boxsize × boxsize × n_rois) containing detected image patches.
 - `x_corners`: Vector of x (column) corner positions in camera coordinates.
 - `y_corners`: Vector of y (row) corner positions in camera coordinates.
 - `frame_indices`: Vector of frame indices for each ROI.
 - `camera`: Camera object for coordinate system tracking.
 - `roi_size`: Size of each ROI.
+
+**BoxesInfo** with processing metadata:
+- `backend`: Compute backend used (`:gpu` or `:cpu`)
+- `elapsed_ns`: Wall time in nanoseconds
+- `device_id`: GPU device ID (0-based), or -1 for CPU
 
 ### How It Works
 The `getboxes()` function applies a Difference of Gaussians (DoG) filter to identify blob-like features. When using the PSF-aware interface, the filter scales are automatically matched to your PSF width for optimal detection sensitivity, and the photon threshold is converted to the appropriate intensity threshold accounting for PSF spreading and filter response.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ camera = IdealCamera(1:256, 1:256, 0.1f0)  # 256×256 pixels, 100nm pixel size
     min_photons = 500.0,           # Minimum photon count to detect
     boxsize = 11)                  # ROI size in pixels
 
-# info contains: backend, elapsed_ns, device_id
-println("Processed in ", info.elapsed_ns / 1e6, " ms on ", info.backend)
+# info contains: backend, elapsed_s, device_id, n_rois, batch_size, n_batches, memory_per_batch
+println("Processed in ", info.elapsed_s * 1000, " ms on ", info.backend)
 ```
 
 ### Primary Parameters (PSF-Aware Interface)
@@ -82,8 +82,12 @@ Tuple of `(ROIBatch, BoxesInfo)`:
 
 **BoxesInfo** with processing metadata:
 - `backend`: Compute backend used (`:gpu` or `:cpu`)
-- `elapsed_ns`: Wall time in nanoseconds
+- `elapsed_s`: Wall time in seconds
 - `device_id`: GPU device ID (0-based), or -1 for CPU
+- `n_rois`: Number of ROIs detected
+- `batch_size`: Frames per batch during processing
+- `n_batches`: Number of batches processed
+- `memory_per_batch`: Estimated memory per batch in bytes
 
 ### How It Works
 The `getboxes()` function applies a Difference of Gaussians (DoG) filter to identify blob-like features. When using the PSF-aware interface, the filter scales are automatically matched to your PSF width for optimal detection sensitivity, and the photon threshold is converted to the appropriate intensity threshold accounting for PSF spreading and filter response.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,48 @@ Pkg.add(url="https://github.com/JuliaSMLM/SMLMBoxer.jl")
 ## Usage
 The main function provided by the package is `getboxes()`, which detects particles or blobs in a multidimensional image stack and returns an `ROIBatch` containing detected regions centered around local maxima. The function uses a Difference of Gaussians (DoG) filter optimized for blob detection and is capable of GPU acceleration.
 
-### Example (Recommended - PSF-Aware Detection)
+### Two Calling Conventions
+
+**Config-based (recommended for reusable settings):**
+```julia
+using SMLMBoxer, SMLMData
+
+camera = IdealCamera(1:256, 1:256, 0.1f0)
+config = BoxerConfig(psf_sigma=0.13, min_photons=500.0, boxsize=11)
+
+(roi_batch, info) = getboxes(imagestack, camera, config)
+```
+
+**Kwargs-based (convenient for one-off calls):**
+```julia
+(roi_batch, info) = getboxes(imagestack, camera;
+    psf_sigma = 0.13,
+    min_photons = 500.0,
+    boxsize = 11)
+```
+
+Both conventions are equivalent - kwargs are forwarded to a BoxerConfig internally.
+
+### BoxerConfig
+
+Configuration struct for ROI detection. Create with `@kwdef` defaults:
+
+```julia
+config = BoxerConfig(
+    # PSF-aware interface (recommended)
+    psf_sigma = 0.13,       # PSF sigma in microns (requires camera)
+    min_photons = 500.0,    # Minimum photons for detection
+
+    # Box parameters
+    boxsize = 11,           # ROI size in pixels
+    overlap = 2.0,          # Max overlap between detections
+
+    # Backend
+    backend = :auto         # :cpu, :gpu, or :auto
+)
+```
+
+### Example (PSF-Aware Detection)
 ```julia
 using SMLMBoxer, SMLMData
 

--- a/api_overview.md
+++ b/api_overview.md
@@ -4,8 +4,9 @@ Particle/blob detection in SMLM image stacks using difference-of-Gaussians filte
 
 ## Exports
 
-**Total exports:** 4
+**Total exports:** 5
 - `getboxes` - Main detection function
+- `BoxesInfo` - Metadata struct returned alongside ROIBatch
 - `recommend_batch_size` - Memory-aware batch sizing utility
 - `ROIBatch` - Re-exported from SMLMData.jl
 - `SingleROI` - Re-exported from SMLMData.jl
@@ -41,7 +42,7 @@ When `SCMOSCamera` is provided, implements SMITE-style inverse variance weightin
 
 ## Core Function
 
-### `getboxes(imagestack, camera=nothing; kwargs...) -> ROIBatch`
+### `getboxes(imagestack, camera=nothing; kwargs...) -> (ROIBatch, BoxesInfo)`
 
 Main detection function. Applies DoG filtering, finds local maxima, extracts ROI patches.
 
@@ -69,13 +70,20 @@ Main detection function. Applies DoG filtering, finds local maxima, extracts ROI
 - `gpu_timeout::Real` - Max seconds to wait in `:gpu` mode (default: Inf)
 - `on_wait::Function` - Optional callback `(elapsed, available, required) -> nothing` for wait progress
 
-**Returns:** `ROIBatch` with fields:
+**Returns:** Tuple of `(ROIBatch, BoxesInfo)`
+
+`ROIBatch` with fields:
 - `data` - ROI stack (boxsize × boxsize × n_rois)
 - `x_corners` - Vector of x (column) corner positions
 - `y_corners` - Vector of y (row) corner positions
 - `frame_indices` - Vector of frame indices for each ROI
 - `camera` - Camera object (provided or default IdealCamera)
 - `roi_size` - Size of each ROI (square)
+
+`BoxesInfo` with fields:
+- `backend` - Compute backend used (`:gpu` or `:cpu`)
+- `elapsed_ns` - Wall time in nanoseconds
+- `device_id` - GPU device ID (0-based), or -1 for CPU
 
 ### `recommend_batch_size(height, width; backend=:auto, memory_fraction=0.8) -> Int`
 
@@ -112,7 +120,7 @@ println("Load up to $max_frames frames at a time")
 for chunk_start in 1:max_frames:total_frames
     chunk_end = min(chunk_start + max_frames - 1, total_frames)
     imagestack = load_frames(chunk_start:chunk_end)
-    roi_batch = getboxes(imagestack, camera; psf_sigma=0.13)
+    (roi_batch, info) = getboxes(imagestack, camera; psf_sigma=0.13)
     # ... process results
 end
 ```
@@ -146,7 +154,7 @@ using SMLMBoxer, SMLMData
 camera = IdealCamera(1:256, 1:256, 0.1f0)
 
 # Detect particles with PSF-aware thresholding
-roi_batch = getboxes(imagestack, camera;
+(roi_batch, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,        # 130nm PSF in microns
     min_photons = 500.0,     # Minimum 500 photons
     boxsize = 11)
@@ -157,6 +165,10 @@ boxes = roi_batch.data              # 11×11×n ROI patches
 positions_x = roi_batch.x_corners   # Column positions
 positions_y = roi_batch.y_corners   # Row positions
 frames = roi_batch.frame_indices
+
+# Check processing info
+println("Backend: ", info.backend)
+println("Elapsed: ", info.elapsed_ns / 1e6, " ms")
 ```
 
 ### sCMOS Variance-Weighted Detection
@@ -168,7 +180,7 @@ readnoise_map = Float32.(load_readnoise_calibration("camera_calib.mat"))
 camera = SCMOSCamera(256, 256, 0.1f0, readnoise_map)
 
 # Variance-weighted detection (automatically enabled)
-roi_batch = getboxes(imagestack, camera;
+(roi_batch, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,
     min_photons = 300.0,  # Lower threshold possible with noise weighting
     backend = :auto)      # GPU with CPU fallback
@@ -177,7 +189,7 @@ roi_batch = getboxes(imagestack, camera;
 ### Advanced: Direct Parameter Control
 ```julia
 # Expert mode: bypass PSF-aware interface
-roi_batch = getboxes(imagestack;
+(roi_batch, info) = getboxes(imagestack;
     sigma_small = 1.5,   # Custom filter sigma (pixels)
     sigma_large = 3.0,
     minval = 10.0,       # Direct intensity threshold
@@ -187,7 +199,7 @@ roi_batch = getboxes(imagestack;
 
 ### Processing Individual ROIs
 ```julia
-roi_batch = getboxes(imagestack, camera; psf_sigma=0.13)
+(roi_batch, info) = getboxes(imagestack, camera; psf_sigma=0.13)
 
 # Iterate over ROIs
 for roi in roi_batch
@@ -196,7 +208,7 @@ for roi in roi_batch
     # - roi.corner: (x, y) corner position
     # - roi.frame_idx: Frame index
     # - roi.camera: Camera ROI calibration
-    
+
     fit_gaussian(roi.data)
 end
 

--- a/api_overview.md
+++ b/api_overview.md
@@ -34,12 +34,31 @@ When `SCMOSCamera` is provided, implements SMITE-style inverse variance weightin
 - High-noise pixels: low weight (reduced false positives)
 - GPU-accelerated via KernelAbstractions.jl (device-agnostic kernels)
 
-### GPU Acceleration
-- Standard DoG: NNlib with cuDNN backend (10-100× speedup)
+### GPU Acceleration and Scheduling
+- Standard DoG: NNlib with cuDNN backend (10-100x speedup)
 - Variance-weighted: KernelAbstractions custom kernels (same code for CPU/GPU)
-- Multi-GPU support: Automatically selects GPU with most free memory
-- Memory waiting: Waits for GPU memory availability instead of crashing when busy
-- Backend selection: `:cpu`, `:gpu`, or `:auto` with configurable timeouts
+- Multi-GPU support: NVML-based polling selects GPU with most free memory across all devices
+
+**Unified GPU retry loop** handles multi-process contention:
+1. Poll all GPUs via NVML (no CUDA context creation) for sufficient free memory and low utilization
+2. Acquire GPU context and run processing
+3. On any failure (no memory, TOCTOU context race, runtime OOM): release memory via `GC.gc() + CUDA.reclaim()`, re-poll NVML with remaining timeout
+4. On timeout: `:auto` falls back to CPU, `:gpu` errors
+5. On success: reclaim GPU memory pool so finished jobs don't block other processes
+
+**Backend modes:**
+- `:cpu` - Always CPU, no GPU involvement
+- `:gpu` - Require GPU, retry until `gpu_timeout` (default: Inf), error if unavailable
+- `:auto` - Try GPU, retry until `auto_timeout` (default: 30s), fall back to CPU
+
+**Wait progress callback:**
+```julia
+config = BoxerConfig(
+    psf_sigma=0.13,
+    backend=:auto,
+    on_wait=(elapsed, available, required) -> @info "Waiting for GPU" elapsed available required
+)
+```
 
 ## Configuration
 
@@ -66,6 +85,7 @@ Configuration struct for ROI detection parameters. Supports `@kwdef` constructio
     backend::Symbol = :auto       # :cpu, :gpu, or :auto
     auto_timeout::Float64 = 30.0  # Max wait for GPU in :auto mode
     gpu_timeout::Float64 = Inf    # Max wait in :gpu mode
+    on_wait::Union{Function,Nothing} = nothing  # Optional wait progress callback
 end
 ```
 
@@ -87,7 +107,7 @@ config = BoxerConfig(psf_sigma=0.13, backend=:gpu, gpu_timeout=60.0)
 
 **Config-based (recommended for reusable settings):**
 ```julia
-getboxes(imagestack, camera, config::BoxerConfig; on_wait=nothing) -> (ROIBatch, BoxesInfo)
+getboxes(imagestack, camera, config::BoxerConfig) -> (ROIBatch, BoxesInfo)
 ```
 
 **Kwargs-based (convenient for one-off calls):**
@@ -358,10 +378,9 @@ Implements optimal inverse variance weighting for spatially-varying noise.
 
 - **GPU Memory Management**: Automatically batches frames if image stack exceeds GPU memory
 - **Type Stability**: All inputs converted to Float32 at entry point
-- **Multi-GPU Support**: `find_best_gpu()` selects GPU with most free memory when multiple GPUs available
-- **Memory Waiting**: With `:gpu` or `:auto` backend, waits for GPU memory instead of crashing
-  - `:auto` waits up to 30s then falls back to CPU
-  - `:gpu` waits indefinitely (or until `gpu_timeout`)
-  - Uses polling with jittered backoff to avoid thundering herd
+- **Multi-GPU NVML Polling**: Scans all GPUs via NVML without creating CUDA contexts. Checks free memory, process contention, and compute utilization. First GPU with sufficient memory and low contention wins.
+- **Contention-Safe Retry**: Unified retry loop handles all GPU failure modes (insufficient memory, TOCTOU context race, runtime OOM). Releases memory and re-polls with remaining timeout budget.
+- **Memory Pool Reclaim**: Calls `GC.gc() + CUDA.reclaim()` after both successful and failed GPU processing to return memory to the system, preventing finished jobs from blocking other processes.
+- **Jittered Backoff**: NVML polling uses jittered sleep intervals to avoid thundering herd when multiple processes compete for GPUs.
 - **Backend Abstraction**: KernelAbstractions enables same code for CPU/GPU variance weighting
-- **Typical Speedup**: 10-100× with GPU depending on image size and number of frames
+- **Typical Speedup**: 10-100x with GPU depending on image size and number of frames

--- a/api_overview.md
+++ b/api_overview.md
@@ -82,8 +82,12 @@ Main detection function. Applies DoG filtering, finds local maxima, extracts ROI
 
 `BoxesInfo` with fields:
 - `backend` - Compute backend used (`:gpu` or `:cpu`)
-- `elapsed_ns` - Wall time in nanoseconds
+- `elapsed_s` - Wall time in seconds
 - `device_id` - GPU device ID (0-based), or -1 for CPU
+- `n_rois` - Number of ROIs detected
+- `batch_size` - Frames per batch during processing
+- `n_batches` - Number of batches processed
+- `memory_per_batch` - Estimated memory per batch in bytes
 
 ### `recommend_batch_size(height, width; backend=:auto, memory_fraction=0.8) -> Int`
 
@@ -168,7 +172,7 @@ frames = roi_batch.frame_indices
 
 # Check processing info
 println("Backend: ", info.backend)
-println("Elapsed: ", info.elapsed_ns / 1e6, " ms")
+println("Elapsed: ", info.elapsed_s * 1000, " ms")
 ```
 
 ### sCMOS Variance-Weighted Detection

--- a/api_overview.md
+++ b/api_overview.md
@@ -4,8 +4,9 @@ Particle/blob detection in SMLM image stacks using difference-of-Gaussians filte
 
 ## Exports
 
-**Total exports:** 5
+**Total exports:** 6
 - `getboxes` - Main detection function
+- `BoxerConfig` - Configuration struct for detection parameters
 - `BoxesInfo` - Metadata struct returned alongside ROIBatch
 - `recommend_batch_size` - Memory-aware batch sizing utility
 - `ROIBatch` - Re-exported from SMLMData.jl
@@ -40,26 +41,81 @@ When `SCMOSCamera` is provided, implements SMITE-style inverse variance weightin
 - Memory waiting: Waits for GPU memory availability instead of crashing when busy
 - Backend selection: `:cpu`, `:gpu`, or `:auto` with configurable timeouts
 
+## Configuration
+
+### `BoxerConfig`
+
+Configuration struct for ROI detection parameters. Supports `@kwdef` construction with defaults.
+
+```julia
+@kwdef struct BoxerConfig
+    # PSF-aware interface (recommended)
+    psf_sigma::Union{Float64,Nothing} = nothing  # PSF sigma in microns
+    min_photons::Float64 = 500.0                 # Minimum photons for detection
+
+    # Advanced interface (direct control)
+    sigma_small::Float64 = 1.0    # Small Gaussian sigma in pixels
+    sigma_large::Float64 = 2.0    # Large Gaussian sigma in pixels
+    minval::Float64 = 0.0         # DoG intensity threshold
+
+    # Box parameters
+    boxsize::Int = 7              # ROI size in pixels
+    overlap::Float64 = 2.0        # Max overlap between detections
+
+    # Backend parameters
+    backend::Symbol = :auto       # :cpu, :gpu, or :auto
+    auto_timeout::Float64 = 30.0  # Max wait for GPU in :auto mode
+    gpu_timeout::Float64 = Inf    # Max wait in :gpu mode
+end
+```
+
+**Usage:**
+```julia
+# PSF-aware (recommended)
+config = BoxerConfig(psf_sigma=0.13, min_photons=500.0, boxsize=11)
+
+# Advanced (direct control)
+config = BoxerConfig(sigma_small=1.5, sigma_large=3.0, minval=10.0)
+
+# GPU-specific
+config = BoxerConfig(psf_sigma=0.13, backend=:gpu, gpu_timeout=60.0)
+```
+
 ## Core Function
 
-### `getboxes(imagestack, camera=nothing; kwargs...) -> (ROIBatch, BoxesInfo)`
+### `getboxes` - Two Calling Conventions
+
+**Config-based (recommended for reusable settings):**
+```julia
+getboxes(imagestack, camera, config::BoxerConfig; on_wait=nothing) -> (ROIBatch, BoxesInfo)
+```
+
+**Kwargs-based (convenient for one-off calls):**
+```julia
+getboxes(imagestack, camera=nothing; kwargs...) -> (ROIBatch, BoxesInfo)
+```
+
+Both conventions are equivalent - kwargs are forwarded to a BoxerConfig internally.
 
 Main detection function. Applies DoG filtering, finds local maxima, extracts ROI patches.
 
 **Arguments:**
 - `imagestack::AbstractArray{<:Real}` - Input image stack (2D or 3D)
 - `camera::Union{AbstractCamera,Nothing}` - Camera object (IdealCamera or SCMOSCamera)
+- `config::BoxerConfig` - Configuration struct (config-based convention)
 
-**Primary Interface (PSF-Aware, Recommended):**
+**Kwargs (kwargs-based convention):**
+
+*PSF-Aware Interface (Recommended):*
 - `psf_sigma::Real` - PSF sigma in microns (requires camera for pixel size conversion)
 - `min_photons::Real` - Minimum total photons for detection (default: 500.0)
 
-**Advanced Interface (Direct Control):**
+*Advanced Interface (Direct Control):*
 - `sigma_small::Real` - Small Gaussian sigma in pixels (default: 1.0)
 - `sigma_large::Real` - Large Gaussian sigma in pixels (default: 2.0)
 - `minval::Real` - DoG intensity threshold (default: 0.0)
 
-**Other Parameters:**
+*Other Parameters:*
 - `boxsize::Int` - ROI size in pixels (default: 7)
 - `overlap::Real` - Maximum overlap between detections in pixels (default: 2.0)
 - `backend::Symbol` - Compute backend: `:cpu`, `:gpu`, or `:auto` (default: `:auto`)
@@ -157,7 +213,11 @@ using SMLMBoxer, SMLMData
 # Create camera with physical pixel size (100nm pixels)
 camera = IdealCamera(1:256, 1:256, 0.1f0)
 
-# Detect particles with PSF-aware thresholding
+# Config-based (recommended for reusable settings)
+config = BoxerConfig(psf_sigma=0.13, min_photons=500.0, boxsize=11)
+(roi_batch, info) = getboxes(imagestack, camera, config)
+
+# OR kwargs-based (convenient for one-off calls)
 (roi_batch, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,        # 130nm PSF in microns
     min_photons = 500.0,     # Minimum 500 photons
@@ -193,6 +253,12 @@ camera = SCMOSCamera(256, 256, 0.1f0, readnoise_map)
 ### Advanced: Direct Parameter Control
 ```julia
 # Expert mode: bypass PSF-aware interface
+
+# Config-based
+config = BoxerConfig(sigma_small=1.5, sigma_large=3.0, minval=10.0, boxsize=9, overlap=1.5)
+(roi_batch, info) = getboxes(imagestack, nothing, config)
+
+# OR kwargs-based
 (roi_batch, info) = getboxes(imagestack;
     sigma_small = 1.5,   # Custom filter sigma (pixels)
     sigma_large = 3.0,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -104,7 +104,7 @@ I_{\text{filtered}} &= \frac{N_{\text{photons}}}{2\pi \sigma_{\text{eff}}^2} \\
 
 where the 0.65 factor accounts for the reduction in peak intensity from the DoG operation (empirically determined for ``\sigma_{\text{large}} = 2\sigma_{\text{small}}``).
 
-### GPU Acceleration
+### GPU Acceleration and Scheduling
 
 SMLMBoxer uses multiple GPU acceleration strategies:
 
@@ -112,7 +112,31 @@ SMLMBoxer uses multiple GPU acceleration strategies:
 2. **Variance-Weighted Filtering**: KernelAbstractions.jl for device-agnostic kernels
 3. **Automatic Memory Management**: Batched processing for large datasets exceeding GPU memory
 
-The `use_gpu` parameter controls GPU usage, with automatic fallback to CPU if CUDA is unavailable.
+The `backend` parameter controls GPU usage: `:cpu`, `:gpu`, or `:auto` (default).
+
+#### Unified GPU Retry Loop
+
+GPU scheduling uses a single retry loop that handles all failure modes under multi-process contention:
+
+1. **NVML Polling**: Scans all GPUs via NVIDIA Management Library without creating CUDA contexts. Checks free memory (with 1.5x safety margin), process contention, and compute utilization (>90% = saturated). Uses jittered backoff to avoid thundering herd.
+
+2. **GPU Acquisition + Processing**: Creates CUDA context on the selected device, runs DoG filtering and local max detection.
+
+3. **Failure Recovery**: On any CUDA error (context creation OOM, runtime OOM, driver errors):
+   - Releases GPU memory: `GC.gc(false)` + `CUDA.reclaim()`
+   - Re-polls NVML with remaining timeout budget
+   - Retries on next available GPU
+
+4. **Timeout Behavior**:
+   - `:auto` mode: falls back to CPU after `auto_timeout` (default 30s)
+   - `:gpu` mode: errors after `gpu_timeout` (default Inf)
+
+5. **Post-Processing Cleanup**: GPU memory pool is reclaimed after both successful and failed processing, so finished jobs release memory for other processes.
+
+This design handles three failure modes uniformly:
+- **No free GPU memory**: NVML poll waits for memory to free up
+- **TOCTOU context race**: NVML says "memory OK" but another process grabs it before `CUDA.device!()` completes
+- **Runtime OOM**: GPU acquired but OOM during actual computation (e.g., cuDNN workspace)
 
 ### Coordinate System
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -44,7 +44,7 @@ roi_batch = getboxes(Float32.(imagestack), camera;
     psf_sigma = 0.13,      # PSF sigma in microns
     min_photons = 500.0,   # Detection threshold
     boxsize = 11,          # ROI size
-    use_gpu = false)       # Set to true for GPU acceleration
+    backend = :cpu)        # Use :auto for GPU acceleration
 
 # Check results
 println("Ground truth: $(length(emitters)) emitters")
@@ -117,7 +117,7 @@ roi_batch = getboxes(Float32.(imagestack), camera;
     psf_sigma = 0.13,
     min_photons = 500.0,
     boxsize = 11,
-    use_gpu = true)  # GPU acceleration for variance weighting
+    backend = :auto)  # GPU with CPU fallback
 
 # Analyze detection uniformity across noise regions
 function count_by_noise_region(batch, n_pixels, split_col)
@@ -169,7 +169,7 @@ for sigma in sigma_values
         sigma_small = sigma,
         sigma_large = 2.0 * sigma,
         minval = 10.0,
-        use_gpu = false)
+        backend = :cpu)
 
     push!(results, (sigma=sigma, n_detected=length(roi_batch)))
 end
@@ -201,16 +201,16 @@ end
 roi_batch_gpu = getboxes(imagestack, camera;
     psf_sigma = 0.13,
     min_photons = 500.0,
-    use_gpu = true)  # Automatically uses GPU if available
+    backend = :auto)  # Try GPU, fall back to CPU
 
 # Benchmark GPU vs CPU
 using BenchmarkTools
 
 @time roi_batch_cpu = getboxes(imagestack, camera;
-    psf_sigma = 0.13, min_photons = 500.0, use_gpu = false)
+    psf_sigma = 0.13, min_photons = 500.0, backend = :cpu)
 
 @time roi_batch_gpu = getboxes(imagestack, camera;
-    psf_sigma = 0.13, min_photons = 500.0, use_gpu = true)
+    psf_sigma = 0.13, min_photons = 500.0, backend = :auto)
 ```
 
 ### Large Dataset Processing
@@ -223,7 +223,7 @@ large_stack = zeros(Float32, 512, 512, 1000)  # 1000 frames
 roi_batch = getboxes(large_stack, camera;
     psf_sigma = 0.13,
     min_photons = 500.0,
-    use_gpu = true)  # Batches frames to fit GPU memory
+    backend = :auto)  # Batches frames to fit GPU memory
 
 println("Processed $(size(large_stack, 3)) frames")
 println("Total detections: $(length(roi_batch))")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -76,7 +76,7 @@ camera = SCMOSCamera(
 roi_batch = getboxes(imagestack, camera;
     psf_sigma = 0.13,
     min_photons = 500.0,
-    use_gpu = true)     # GPU acceleration for variance weighting
+    backend = :auto)    # GPU with CPU fallback
 ```
 
 ## How It Works

--- a/examples/README.md
+++ b/examples/README.md
@@ -122,8 +122,8 @@ psf_sigma_pixels = psf_sigma_microns / pixel_size_microns
 
 # Detect with clear physical parameters
 roi_batch = getboxes(images, camera;
-    psf_sigma = psf_sigma_pixels,  # Automatically sets DoG scales
-    min_photons = 500.0)            # Physical photon threshold
+    psf_sigma = psf_sigma_microns,  # Automatically sets DoG scales
+    min_photons = 500.0)             # Physical photon threshold
 ```
 
 **Benefits:**

--- a/examples/basic_detection.jl
+++ b/examples/basic_detection.jl
@@ -111,7 +111,7 @@ println("  Running on clean image (CPU)...")
     min_photons = 500.0,            # Detect emitters with ≥500 photons
     boxsize = 11,                   # Larger box for better fitting
     overlap = 3.0,
-    use_gpu = false
+    backend = :cpu
 )
 t_clean = info_clean.elapsed_s
 
@@ -122,7 +122,7 @@ println("  Running on noisy image (CPU)...")
     min_photons = 500.0,
     boxsize = 11,
     overlap = 3.0,
-    use_gpu = false
+    backend = :cpu
 )
 t_noisy = info_noisy.elapsed_s
 
@@ -134,7 +134,7 @@ if CUDA.functional()
         min_photons = 500.0,
         boxsize = 11,
         overlap = 3.0,
-        use_gpu = true
+        backend = :gpu
     )
     t_gpu = info_gpu.elapsed_s
 else

--- a/examples/basic_detection.jl
+++ b/examples/basic_detection.jl
@@ -106,42 +106,40 @@ println()
 
 # Detect on clean image (CPU)
 println("  Running on clean image (CPU)...")
-t_start = time()
-roi_batch_clean = getboxes(img_clean, camera;
+(roi_batch_clean, info_clean) = getboxes(img_clean, camera;
     psf_sigma = psf_sigma_pixels,  # PSF-aware detection
     min_photons = 500.0,            # Detect emitters with ≥500 photons
     boxsize = 11,                   # Larger box for better fitting
     overlap = 3.0,
     use_gpu = false
 )
-t_clean = time() - t_start
+t_clean = info_clean.elapsed_ns / 1e9
 
 # Detect on noisy image (CPU)
 println("  Running on noisy image (CPU)...")
-t_start = time()
-roi_batch_noisy = getboxes(img_noisy, camera;
+(roi_batch_noisy, info_noisy) = getboxes(img_noisy, camera;
     psf_sigma = psf_sigma_pixels,
     min_photons = 500.0,
     boxsize = 11,
     overlap = 3.0,
     use_gpu = false
 )
-t_noisy = time() - t_start
+t_noisy = info_noisy.elapsed_ns / 1e9
 
 # Try GPU if available
 if CUDA.functional()
     println("  Running on noisy image (GPU)...")
-    t_start = time()
-    roi_batch_gpu = getboxes(img_noisy, camera;
+    (roi_batch_gpu, info_gpu) = getboxes(img_noisy, camera;
         psf_sigma = psf_sigma_pixels,
         min_photons = 500.0,
         boxsize = 11,
         overlap = 3.0,
         use_gpu = true
     )
-    t_gpu = time() - t_start
+    t_gpu = info_gpu.elapsed_ns / 1e9
 else
     roi_batch_gpu = nothing
+    info_gpu = nothing
     t_gpu = NaN
 end
 

--- a/examples/basic_detection.jl
+++ b/examples/basic_detection.jl
@@ -113,7 +113,7 @@ println("  Running on clean image (CPU)...")
     overlap = 3.0,
     use_gpu = false
 )
-t_clean = info_clean.elapsed_ns / 1e9
+t_clean = info_clean.elapsed_s
 
 # Detect on noisy image (CPU)
 println("  Running on noisy image (CPU)...")
@@ -124,7 +124,7 @@ println("  Running on noisy image (CPU)...")
     overlap = 3.0,
     use_gpu = false
 )
-t_noisy = info_noisy.elapsed_ns / 1e9
+t_noisy = info_noisy.elapsed_s
 
 # Try GPU if available
 if CUDA.functional()
@@ -136,7 +136,7 @@ if CUDA.functional()
         overlap = 3.0,
         use_gpu = true
     )
-    t_gpu = info_gpu.elapsed_ns / 1e9
+    t_gpu = info_gpu.elapsed_s
 else
     roi_batch_gpu = nothing
     info_gpu = nothing

--- a/examples/blinking_workflow_ideal.jl
+++ b/examples/blinking_workflow_ideal.jl
@@ -145,7 +145,7 @@ println()
     min_photons = 50.0,             # Photon threshold (auto-converts to intensity)
     boxsize = 11,                   # 11×11 pixel ROIs
     overlap = 3.0,                  # Max 3 pixel overlap
-    use_gpu = false                 # Use CPU (set to true if CUDA available)
+    backend = :cpu                   # Use :auto for GPU acceleration
 )
 t_detect = info.elapsed_s
 

--- a/examples/blinking_workflow_ideal.jl
+++ b/examples/blinking_workflow_ideal.jl
@@ -140,15 +140,14 @@ println("  Detection threshold: 50 photons (matched to framerate)")
 println()
 
 # Detect using PSF-aware interface with physical units
-t_start = time()
-roi_batch = getboxes(images, camera;
+(roi_batch, info) = getboxes(images, camera;
     psf_sigma = sim_params.σ_psf,  # PSF sigma in microns (auto-converts to pixels)
     min_photons = 50.0,             # Photon threshold (auto-converts to intensity)
     boxsize = 11,                   # 11×11 pixel ROIs
     overlap = 3.0,                  # Max 3 pixel overlap
     use_gpu = false                 # Use CPU (set to true if CUDA available)
 )
-t_detect = time() - t_start
+t_detect = info.elapsed_ns / 1e9
 
 n_detected = length(roi_batch)
 

--- a/examples/blinking_workflow_ideal.jl
+++ b/examples/blinking_workflow_ideal.jl
@@ -147,7 +147,7 @@ println()
     overlap = 3.0,                  # Max 3 pixel overlap
     use_gpu = false                 # Use CPU (set to true if CUDA available)
 )
-t_detect = info.elapsed_ns / 1e9
+t_detect = info.elapsed_s
 
 n_detected = length(roi_batch)
 

--- a/examples/blinking_workflow_scmos.jl
+++ b/examples/blinking_workflow_scmos.jl
@@ -165,7 +165,7 @@ println()
     min_photons = 50.0,
     boxsize = 11,
     overlap = 3.0,
-    use_gpu = false
+    backend = :cpu
 )
 t_detect_scmos = info_scmos.elapsed_s
 
@@ -185,7 +185,7 @@ println("Step 6: Detecting with IdealCamera (for comparison)...")
     min_photons = 50.0,
     boxsize = 11,
     overlap = 3.0,
-    use_gpu = false
+    backend = :cpu
 )
 t_detect_ideal = info_ideal.elapsed_s
 

--- a/examples/blinking_workflow_scmos.jl
+++ b/examples/blinking_workflow_scmos.jl
@@ -167,7 +167,7 @@ println()
     overlap = 3.0,
     use_gpu = false
 )
-t_detect_scmos = info_scmos.elapsed_ns / 1e9
+t_detect_scmos = info_scmos.elapsed_s
 
 n_detected_scmos = length(roi_batch_scmos)
 println("  sCMOS detection complete ($(round(t_detect_scmos * 1000, digits=1)) ms, backend=$(info_scmos.backend))")
@@ -187,7 +187,7 @@ println("Step 6: Detecting with IdealCamera (for comparison)...")
     overlap = 3.0,
     use_gpu = false
 )
-t_detect_ideal = info_ideal.elapsed_ns / 1e9
+t_detect_ideal = info_ideal.elapsed_s
 
 n_detected_ideal = length(roi_batch_ideal)
 println("  IdealCamera detection complete ($(round(t_detect_ideal * 1000, digits=1)) ms)")

--- a/examples/blinking_workflow_scmos.jl
+++ b/examples/blinking_workflow_scmos.jl
@@ -160,18 +160,17 @@ println("  Detection threshold: 50 photons (matched to framerate)")
 println("  Using variance-weighted DoG filtering (sCMOS-optimized)")
 println()
 
-t_start = time()
-roi_batch_scmos = getboxes(images_scmos, camera_scmos;
+(roi_batch_scmos, info_scmos) = getboxes(images_scmos, camera_scmos;
     psf_sigma = sim_params.σ_psf,  # Physical units (microns)
     min_photons = 50.0,
     boxsize = 11,
     overlap = 3.0,
     use_gpu = false
 )
-t_detect_scmos = time() - t_start
+t_detect_scmos = info_scmos.elapsed_ns / 1e9
 
 n_detected_scmos = length(roi_batch_scmos)
-println("  sCMOS detection complete ($(round(t_detect_scmos * 1000, digits=1)) ms)")
+println("  sCMOS detection complete ($(round(t_detect_scmos * 1000, digits=1)) ms, backend=$(info_scmos.backend))")
 println("  Detected: $n_detected_scmos")
 println("  Detection rate: $(round(n_detected_scmos / n_emitters * 100, digits=1))%")
 println()
@@ -181,15 +180,14 @@ println()
 # ============================================================================
 println("Step 6: Detecting with IdealCamera (for comparison)...")
 
-t_start = time()
-roi_batch_ideal = getboxes(images_ideal, camera_ideal;
+(roi_batch_ideal, info_ideal) = getboxes(images_ideal, camera_ideal;
     psf_sigma = sim_params.σ_psf,  # Physical units (microns)
     min_photons = 50.0,
     boxsize = 11,
     overlap = 3.0,
     use_gpu = false
 )
-t_detect_ideal = time() - t_start
+t_detect_ideal = info_ideal.elapsed_ns / 1e9
 
 n_detected_ideal = length(roi_batch_ideal)
 println("  IdealCamera detection complete ($(round(t_detect_ideal * 1000, digits=1)) ms)")

--- a/examples/scmos_detection.jl
+++ b/examples/scmos_detection.jl
@@ -129,7 +129,7 @@ println()
     overlap = 3.0,
     use_gpu = false
 )
-t_cpu = info_cpu.elapsed_ns / 1e9
+t_cpu = info_cpu.elapsed_s
 
 println("  Detected $(length(roi_batch)) spots (CPU)")
 println("  Processing time: $(round(t_cpu * 1000, digits=1)) ms")
@@ -144,7 +144,7 @@ if CUDA.functional()
         overlap = 3.0,
         use_gpu = true
     )
-    t_gpu = info_gpu.elapsed_ns / 1e9
+    t_gpu = info_gpu.elapsed_s
 
     println("  Detected $(length(roi_batch_gpu)) spots (GPU, device=$(info_gpu.device_id))")
     println("  Processing time: $(round(t_gpu * 1000, digits=1)) ms")

--- a/examples/scmos_detection.jl
+++ b/examples/scmos_detection.jl
@@ -122,15 +122,14 @@ println("  PSF sigma: $(round(psf_sigma_pixels, digits=2)) pixels")
 println("  Detection threshold: 500 photons")
 println()
 
-t_start = time()
-roi_batch = getboxes(img_scmos, camera_scmos;
+(roi_batch, info_cpu) = getboxes(img_scmos, camera_scmos;
     psf_sigma = psf_sigma_pixels,  # PSF-aware detection
     min_photons = 500.0,            # Detect emitters with ≥500 photons
     boxsize = 11,                   # Larger box for better fitting
     overlap = 3.0,
     use_gpu = false
 )
-t_cpu = time() - t_start
+t_cpu = info_cpu.elapsed_ns / 1e9
 
 println("  Detected $(length(roi_batch)) spots (CPU)")
 println("  Processing time: $(round(t_cpu * 1000, digits=1)) ms")
@@ -138,17 +137,16 @@ println("  Processing time: $(round(t_cpu * 1000, digits=1)) ms")
 # GPU detection if available
 if CUDA.functional()
     println("  Running GPU detection...")
-    t_start = time()
-    roi_batch_gpu = getboxes(img_scmos, camera_scmos;
+    (roi_batch_gpu, info_gpu) = getboxes(img_scmos, camera_scmos;
         psf_sigma = psf_sigma_pixels,
         min_photons = 500.0,
         boxsize = 11,
         overlap = 3.0,
         use_gpu = true
     )
-    t_gpu = time() - t_start
+    t_gpu = info_gpu.elapsed_ns / 1e9
 
-    println("  Detected $(length(roi_batch_gpu)) spots (GPU)")
+    println("  Detected $(length(roi_batch_gpu)) spots (GPU, device=$(info_gpu.device_id))")
     println("  Processing time: $(round(t_gpu * 1000, digits=1)) ms")
     println("  GPU speedup: $(round(t_cpu/t_gpu, digits=1))x")
 end

--- a/examples/scmos_detection.jl
+++ b/examples/scmos_detection.jl
@@ -127,7 +127,7 @@ println()
     min_photons = 500.0,            # Detect emitters with ≥500 photons
     boxsize = 11,                   # Larger box for better fitting
     overlap = 3.0,
-    use_gpu = false
+    backend = :cpu
 )
 t_cpu = info_cpu.elapsed_s
 
@@ -142,7 +142,7 @@ if CUDA.functional()
         min_photons = 500.0,
         boxsize = 11,
         overlap = 3.0,
-        use_gpu = true
+        backend = :gpu
     )
     t_gpu = info_gpu.elapsed_s
 

--- a/src/SMLMBoxer.jl
+++ b/src/SMLMBoxer.jl
@@ -24,7 +24,7 @@ using Statistics: mean  # For mean gain/QE in threshold calculation
 
 # Re-export ROIBatch and SingleROI from SMLMData for convenience
 using SMLMData: ROIBatch, SingleROI
-export getboxes, ROIBatch, SingleROI, BoxesInfo, recommend_batch_size
+export getboxes, ROIBatch, SingleROI, BoxerConfig, BoxesInfo, recommend_batch_size
 
 include("gpu.jl")
 include("types.jl")

--- a/src/SMLMBoxer.jl
+++ b/src/SMLMBoxer.jl
@@ -24,7 +24,7 @@ using Statistics: mean  # For mean gain/QE in threshold calculation
 
 # Re-export ROIBatch and SingleROI from SMLMData for convenience
 using SMLMData: ROIBatch, SingleROI
-export getboxes, ROIBatch, SingleROI, recommend_batch_size
+export getboxes, ROIBatch, SingleROI, BoxesInfo, recommend_batch_size
 
 include("gpu.jl")
 include("types.jl")

--- a/src/SMLMBoxer.jl
+++ b/src/SMLMBoxer.jl
@@ -23,7 +23,7 @@ using SMLMData
 using Statistics: mean  # For mean gain/QE in threshold calculation
 
 # Re-export ROIBatch and SingleROI from SMLMData for convenience
-using SMLMData: ROIBatch, SingleROI
+using SMLMData: ROIBatch, SingleROI, AbstractSMLMConfig, AbstractSMLMInfo
 export getboxes, ROIBatch, SingleROI, BoxerConfig, BoxesInfo, recommend_batch_size
 
 include("gpu.jl")

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -22,7 +22,10 @@ has_cuda() = CUDA.functional()
 Find the GPU with the most free memory and switch to it.
 
 Returns the device index (0-based). On single-GPU systems, returns 0 immediately.
-Logs selection info when multiple GPUs are available.
+
+Uses NVML to query free memory on each device without creating CUDA contexts,
+avoiding `cuDevicePrimaryCtxRetain` OOM errors under multi-process contention.
+Only calls `CUDA.device!()` once on the selected device.
 
 # Example
 ```julia
@@ -35,14 +38,15 @@ function find_best_gpu()
     n = length(CUDA.devices())
     n == 1 && return 0
 
+    # Query memory via NVML (no CUDA context needed, safe under contention)
     best, maxfree = 0, 0
     for i in 0:(n-1)
-        CUDA.device!(i)
-        free = CUDA.free_memory()
-        if free > maxfree
-            maxfree, best = free, i
+        info = CUDA.NVML.memory_info(CUDA.NVML.Device(i))
+        if info.free > maxfree
+            maxfree, best = info.free, i
         end
     end
+
     CUDA.device!(best)
     @info "Selected GPU $best with $(Base.format_bytes(maxfree)) free"
     return best

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -53,9 +53,89 @@ function find_best_gpu()
 end
 
 """
+    poll_gpu_nvml(required_bytes; timeout=30.0, poll=0.5, on_wait=nothing) -> (Bool, Int)
+
+Poll ALL GPUs via NVML until one has sufficient free memory and low contention.
+No CUDA context creation needed - safe under multi-process contention.
+
+# Arguments
+- `required_bytes`: Minimum bytes needed (1.5x safety margin applied internally)
+- `timeout`: Maximum seconds to poll (default 30.0, use Inf for unlimited)
+- `poll`: Seconds between checks (default 0.5)
+- `on_wait`: Optional callback(elapsed, best_available, required) called each poll
+
+# Returns
+- `(true, device_id)` if a GPU became available, `(false, -1)` if timeout reached
+
+# Contention Detection
+A GPU is considered contended when other processes are present AND either:
+- Free memory is insufficient (< required × 1.5)
+- Compute utilization exceeds 90%
+
+When other processes are present but memory is sufficient and utilization is low,
+the GPU is still considered available.
+"""
+function poll_gpu_nvml(required_bytes::Integer;
+        timeout::Real = 30.0,
+        poll::Real = 0.5,
+        on_wait = nothing)
+
+    n = length(CUDA.devices())
+    required_with_margin = required_bytes * 1.5
+
+    deadline = time() + timeout
+    start = time()
+
+    while time() < deadline
+        best_device = -1
+        best_free = 0
+
+        for i in 0:(n-1)
+            dev = CUDA.NVML.Device(i)
+            info = CUDA.NVML.memory_info(dev)
+
+            # Not enough memory on this device
+            info.free < required_with_margin && continue
+
+            # Check contention: other processes on this GPU
+            procs = CUDA.NVML.compute_processes(dev)
+            other_procs = length(procs) - (getpid() in keys(procs) ? 1 : 0)
+
+            if other_procs > 0
+                rates = CUDA.NVML.utilization_rates(dev)
+                rates.compute > 0.9 && continue  # GPU saturated, skip
+            end
+
+            # This GPU is available - track best (most free memory)
+            if info.free > best_free
+                best_free = info.free
+                best_device = i
+            end
+        end
+
+        if best_device >= 0
+            return (true, best_device)
+        end
+
+        # Callback for progress reporting
+        if on_wait !== nothing
+            # Report best available across all GPUs for visibility
+            max_free = maximum(CUDA.NVML.memory_info(CUDA.NVML.Device(i)).free for i in 0:(n-1))
+            on_wait(time() - start, max_free, required_bytes)
+        end
+
+        # Jittered sleep to desync competing processes
+        sleep(poll * (1.0 + 0.2 * (rand() - 0.5)))
+    end
+
+    return (false, -1)
+end
+
+"""
     wait_for_gpu_memory(required_bytes; timeout=30.0, poll=0.5, on_wait=nothing) -> Bool
 
-Wait until GPU has sufficient available memory.
+Wait until current GPU device has sufficient available memory.
+Uses CUDA calls (requires active context). Used by :gpu mode after device selection.
 
 # Arguments
 - `required_bytes`: Minimum bytes needed (with safety margin applied internally)
@@ -65,25 +145,18 @@ Wait until GPU has sufficient available memory.
 
 # Returns
 - `true` if memory became available, `false` if timeout reached
-
-# Notes
-- Calls CUDA.reclaim() before each check to free cached memory
-- Applies 1.5x safety margin for fragmentation
-- Uses jittered polling to desync competing processes
 """
 function wait_for_gpu_memory(required_bytes::Integer;
         timeout::Real = 30.0,
         poll::Real = 0.5,
         on_wait = nothing)
 
-    # Safety margin for fragmentation (free_memory can be fragmented)
     required_with_margin = required_bytes * 1.5
 
     deadline = time() + timeout
     start = time()
 
     while time() < deadline
-        # Try to free cached memory
         CUDA.reclaim()
 
         available = CUDA.free_memory()
@@ -91,12 +164,10 @@ function wait_for_gpu_memory(required_bytes::Integer;
             return true
         end
 
-        # Callback for progress reporting
         if on_wait !== nothing
             on_wait(time() - start, available, required_bytes)
         end
 
-        # Jittered sleep to desync competing allocators
         sleep(poll * (1.0 + 0.2 * (rand() - 0.5)))
     end
 
@@ -105,9 +176,16 @@ end
 
 """
     select_backend(backend::Symbol, required_bytes;
-                   auto_timeout=30.0, gpu_timeout=Inf, on_wait=nothing) -> Symbol
+                   auto_timeout=30.0, gpu_timeout=Inf, on_wait=nothing) -> (Symbol, Int)
 
-Select compute backend with GPU memory waiting.
+Select compute backend with two-layer GPU contention handling.
+
+Layer 1 (NVML polling): Scans all GPUs via NVML without creating CUDA contexts.
+Polls through timeout with jittered backoff. First GPU with sufficient free memory
+and low contention wins. Safe under multi-process contention.
+
+Layer 2 (runtime try/catch): Applied by caller for :auto mode. If CUDA errors
+occur during processing despite NVML pre-check, falls back to CPU.
 
 # Arguments
 - `backend`: :cpu, :gpu, or :auto
@@ -117,19 +195,12 @@ Select compute backend with GPU memory waiting.
 - `on_wait`: Optional callback(elapsed, available, required)
 
 # Returns
-- `:cpu` or `:gpu` - the actual backend to use
+- `(backend::Symbol, device_id::Int)` - selected backend and GPU device (0-based, -1 for CPU)
 
 # Behavior
-- `:cpu` - Always returns :cpu, no waiting
-- `:gpu` - Requires GPU, waits up to gpu_timeout, errors if unavailable/timeout
-- `:auto` - Tries GPU with auto_timeout wait, falls back to CPU with warning
-
-# Example
-```julia
-backend = select_backend(:auto, 1_000_000_000;  # 1GB needed
-    auto_timeout = 30.0,
-    on_wait = (e, a, r) -> @info "Waiting..." elapsed=round(e,digits=1))
-```
+- `:cpu` - Returns (:cpu, -1) immediately
+- `:gpu` - NVML poll for device, then CUDA wait_for_gpu_memory. Errors if unavailable/timeout
+- `:auto` - NVML poll for device with timeout, falls back to (:cpu, -1) with warning
 """
 function select_backend(backend::Symbol, required_bytes::Integer;
         auto_timeout::Real = 30.0,
@@ -139,35 +210,43 @@ function select_backend(backend::Symbol, required_bytes::Integer;
     backend in (:cpu, :gpu, :auto) || error("backend must be :cpu, :gpu, or :auto")
 
     if backend == :cpu
-        return :cpu
+        return (:cpu, -1)
 
     elseif backend == :gpu
-        # User explicitly requested GPU - must have it
         if !has_cuda() || !CUDA.functional()
             error("GPU backend requested but CUDA is not functional")
         end
 
-        # Wait for memory (possibly forever)
-        if !wait_for_gpu_memory(required_bytes; timeout=gpu_timeout, on_wait=on_wait)
-            error("GPU memory not available after $(gpu_timeout)s. " *
+        # NVML poll to find available device (no CUDA context)
+        available, device_id = poll_gpu_nvml(required_bytes; timeout=gpu_timeout, on_wait=on_wait)
+        if !available
+            error("No GPU available after $(gpu_timeout)s. " *
+                  "Required: $(Base.format_bytes(required_bytes))")
+        end
+
+        # Activate chosen device and confirm memory via CUDA
+        CUDA.device!(device_id)
+        if !wait_for_gpu_memory(required_bytes; timeout=min(gpu_timeout, 10.0), on_wait=on_wait)
+            error("GPU $device_id memory not available. " *
                   "Required: $(Base.format_bytes(required_bytes)), " *
                   "Available: $(Base.format_bytes(CUDA.free_memory()))")
         end
-        return :gpu
+        return (:gpu, device_id)
 
     else  # :auto
-        # Try GPU if available, fall back to CPU
         if !has_cuda() || !CUDA.functional()
-            return :cpu
+            return (:cpu, -1)
         end
 
-        if wait_for_gpu_memory(required_bytes; timeout=auto_timeout, on_wait=on_wait)
-            return :gpu
+        # NVML poll all GPUs - no CUDA context creation
+        available, device_id = poll_gpu_nvml(required_bytes; timeout=auto_timeout, on_wait=on_wait)
+        if available
+            CUDA.device!(device_id)
+            return (:gpu, device_id)
         else
-            @warn "GPU memory not available after $(auto_timeout)s, using CPU. " *
-                  "Required: $(Base.format_bytes(required_bytes)), " *
-                  "Available: $(Base.format_bytes(CUDA.free_memory()))"
-            return :cpu
+            @warn "No GPU available after $(auto_timeout)s, using CPU. " *
+                  "Required: $(Base.format_bytes(required_bytes))"
+            return (:cpu, -1)
         end
     end
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -273,60 +273,45 @@ function _getboxes_impl(args::GetBoxesArgs)
   nrows, ncols = size(imagestack, 1), size(imagestack, 2)
   min_memory_needed = estimate_gpu_memory_per_frame(nrows, ncols, args.camera)
 
-  actual_backend = select_backend(args.backend, min_memory_needed;
+  # select_backend handles NVML polling + device selection (Layer 1)
+  actual_backend, device_id = select_backend(args.backend, min_memory_needed;
       auto_timeout = args.auto_timeout,
       gpu_timeout = args.gpu_timeout,
       on_wait = args.on_wait)
 
   args.use_gpu = (actual_backend == :gpu)
 
-  # Track device and batch info for BoxesInfo
-  device_id = -1  # CPU default
+  # Track batch info for BoxesInfo
   batch_size = 0
   n_batches = 0
   memory_per_batch = 0
 
   if args.use_gpu
-      # GPU path - wrap in fallback for :auto mode
-      gpu_failed = false
+      # GPU path - Layer 2: runtime try/catch for :auto mode
       if args.backend == :auto
           try
-              find_best_gpu()
-              device_id = Int(CUDA.device().handle)
               max_free_mem = CUDA.free_memory()
-
               coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
                   imagestack, args, kernelsize, max_free_mem; use_gpu=true)
-
               CUDA.synchronize()
           catch e
               @warn "GPU processing failed, falling back to CPU" exception=e
-              gpu_failed = true
               device_id = -1
               actual_backend = :cpu
               args.use_gpu = false
           end
       else
           # :gpu mode - no fallback, let errors propagate
-          find_best_gpu()
-          device_id = Int(CUDA.device().handle)
           max_free_mem = CUDA.free_memory()
-
           coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
               imagestack, args, kernelsize, max_free_mem; use_gpu=true)
-
           CUDA.synchronize()
-      end
-
-      if gpu_failed
-          # Fall through to CPU path
       end
   end
 
   if !args.use_gpu
       # CPU path with GC cleanup between batches
       max_free_mem = Sys.free_memory()
-
       coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
           imagestack, args, kernelsize, max_free_mem;
           use_gpu=false,

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -49,8 +49,12 @@ Tuple of `(ROIBatch, BoxesInfo)`:
 
 `BoxesInfo` with the following fields:
 - `backend`: Compute backend used (:gpu or :cpu)
-- `elapsed_ns`: Wall time in nanoseconds
+- `elapsed_s`: Wall time in seconds
 - `device_id`: GPU device ID (0-based), or -1 for CPU
+- `n_rois`: Number of ROIs detected
+- `batch_size`: Frames per batch during processing
+- `n_batches`: Number of batches processed
+- `memory_per_batch`: Estimated memory per batch in bytes
 
 # Details on filtering
 
@@ -107,7 +111,7 @@ frames = roi_batch.frame_indices
 
 # Check processing info
 println("Backend: ", info.backend)
-println("Elapsed: ", info.elapsed_ns / 1e6, " ms")
+println("Elapsed: ", info.elapsed_s * 1000, " ms")
 
 # Advanced: Direct control over filter parameters
 (roi_batch, info) = getboxes(imagestack;
@@ -304,8 +308,8 @@ function _getboxes_impl(args::GetBoxesArgs)
   end
 
   roi_batch = ROIBatch(boxstack, x_corners, y_corners, frame_indices, camera)
-  elapsed_ns = time_ns() - start_ns
-  info = BoxesInfo(actual_backend, elapsed_ns, device_id, n_rois, batch_size, n_batches, memory_per_batch)
+  elapsed_s = (time_ns() - start_ns) / 1e9
+  info = BoxesInfo(actual_backend, elapsed_s, device_id, n_rois, batch_size, n_batches, memory_per_batch)
 
   return (roi_batch, info)
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -266,6 +266,7 @@ function _getboxes_impl(args::GetBoxesArgs)
   min_memory_needed = estimate_gpu_memory_per_frame(nrows, ncols, args.camera)
 
   # select_backend handles NVML polling + device selection (Layer 1)
+  gpu_start = time()
   actual_backend, device_id = select_backend(args.backend, min_memory_needed;
       auto_timeout = args.auto_timeout,
       gpu_timeout = args.gpu_timeout,
@@ -281,18 +282,42 @@ function _getboxes_impl(args::GetBoxesArgs)
   if args.use_gpu
       # GPU path - Layer 2: runtime try/catch for :auto mode
       if args.backend == :auto
-          try
-              max_free_mem = CUDA.free_memory()
-              coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
-                  imagestack, args, kernelsize, max_free_mem; use_gpu=true)
-              CUDA.synchronize()
-          catch e
-              @warn "GPU processing failed, falling back to CPU" exception=e
-              GC.gc(false)
-              CUDA.reclaim()
-              device_id = -1
-              actual_backend = :cpu
-              args.use_gpu = false
+          gpu_succeeded = false
+          while !gpu_succeeded
+              try
+                  max_free_mem = CUDA.free_memory()
+                  coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
+                      imagestack, args, kernelsize, max_free_mem; use_gpu=true)
+                  CUDA.synchronize()
+                  gpu_succeeded = true
+              catch e
+                  @warn "GPU processing failed, releasing memory and retrying" exception=e
+                  GC.gc(false)
+                  CUDA.reclaim()
+
+                  remaining = args.auto_timeout - (time() - gpu_start)
+                  if remaining <= 0
+                      @warn "GPU retry timeout expired, falling back to CPU"
+                      device_id = -1
+                      actual_backend = :cpu
+                      args.use_gpu = false
+                      break
+                  end
+
+                  # Re-poll NVML with remaining timeout budget
+                  available, new_device_id = poll_gpu_nvml(min_memory_needed;
+                      timeout=remaining, on_wait=args.on_wait)
+                  if available
+                      CUDA.device!(new_device_id)
+                      device_id = new_device_id
+                  else
+                      @warn "No GPU available after retry, falling back to CPU"
+                      device_id = -1
+                      actual_backend = :cpu
+                      args.use_gpu = false
+                      break
+                  end
+              end
           end
       else
           # :gpu mode - no fallback, let errors propagate

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -34,7 +34,6 @@ Note: If `psf_sigma` is provided, it overrides sigma_small/sigma_large/minval.
 - `auto_timeout::Real`: Max seconds to wait for GPU memory in `:auto` mode (default: 30.0).
 - `gpu_timeout::Real`: Max seconds to wait for GPU memory in `:gpu` mode (default: Inf).
 - `on_wait::Function`: Optional callback `(elapsed, available, required) -> nothing` for wait progress.
-- `use_gpu::Bool`: DEPRECATED - use `backend` instead. If provided, `true` maps to `:auto`, `false` to `:cpu`.
 
 # Returns
 Tuple of `(ROIBatch, BoxesInfo)`:
@@ -82,13 +81,13 @@ where variance = readnoise². This implements optimal inverse variance weighting
 This significantly improves detection sensitivity in sCMOS data with spatially-varying noise.
 
 **GPU Acceleration:** Variance-weighted filtering uses KernelAbstractions.jl for device-agnostic
-computation. The same kernel code runs on both CPU and GPU, automatically selected based on `use_gpu`.
+computation. The same kernel code runs on both CPU and GPU, automatically selected based on `backend`.
 This provides GPU acceleration for sCMOS cameras (10-100x speedup on large images).
 
 ## Standard Filtering (IdealCamera or no camera)
 
 Standard DoG convolution is used when no camera is provided or with IdealCamera.
-The convolution is performed via NNlib (using cuDNN on GPU) or CPU, depending on `use_gpu`.
+The convolution is performed via NNlib (using cuDNN on GPU) or CPU, depending on `backend`.
 
 After filtering, local maxima above `minval` are identified. Boxes are cut
 out around each maximum, excluding overlaps.
@@ -127,8 +126,7 @@ end
 ```
 """
 # Config-based calling convention (primary)
-function getboxes(imagestack::AbstractArray{<:Real}, camera::Union{AbstractCamera,Nothing}, config::BoxerConfig;
-                  on_wait::Union{Function,Nothing}=nothing)
+function getboxes(imagestack::AbstractArray{<:Real}, camera::Union{AbstractCamera,Nothing}, config::BoxerConfig)
   # Convert to Float32 for type stability throughout pipeline
   imagestack_f32 = imagestack isa AbstractArray{Float32} ? imagestack : Float32.(imagestack)
 
@@ -146,7 +144,7 @@ function getboxes(imagestack::AbstractArray{<:Real}, camera::Union{AbstractCamer
       backend=config.backend,
       auto_timeout=config.auto_timeout,
       gpu_timeout=config.gpu_timeout,
-      on_wait=on_wait
+      on_wait=config.on_wait
   )
   return _getboxes_impl(args)
 end
@@ -163,14 +161,7 @@ function getboxes(imagestack::AbstractArray{<:Real}, camera::Union{AbstractCamer
                   backend::Symbol=:auto,
                   auto_timeout::Real=30.0,
                   gpu_timeout::Real=Inf,
-                  on_wait::Union{Function,Nothing}=nothing,
-                  use_gpu::Union{Bool,Nothing}=nothing)  # Deprecated
-  # Handle deprecated use_gpu
-  actual_backend = backend
-  if use_gpu !== nothing
-      actual_backend = use_gpu ? :auto : :cpu
-  end
-
+                  on_wait::Union{Function,Nothing}=nothing)
   # Build config from kwargs
   config = BoxerConfig(
       psf_sigma=psf_sigma === nothing ? nothing : Float64(psf_sigma),
@@ -180,12 +171,13 @@ function getboxes(imagestack::AbstractArray{<:Real}, camera::Union{AbstractCamer
       minval=Float64(minval === nothing ? 0.0 : minval),
       boxsize=boxsize,
       overlap=Float64(overlap),
-      backend=actual_backend,
+      backend=backend,
       auto_timeout=Float64(auto_timeout),
-      gpu_timeout=Float64(gpu_timeout)
+      gpu_timeout=Float64(gpu_timeout),
+      on_wait=on_wait
   )
 
-  return getboxes(imagestack, camera, config; on_wait=on_wait)
+  return getboxes(imagestack, camera, config)
 end
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -216,10 +216,49 @@ function _getboxes_impl(args::GetBoxesArgs)
 
       CUDA.synchronize()
   else
-      filtered_stack = dog_filter(imagestack, args)
-      coords = findlocalmax(filtered_stack, kernelsize; minval=args.minval, use_gpu=args.use_gpu)
+      # CPU path with memory-aware batching (mirrors GPU batching logic)
+      max_free_mem = Sys.free_memory()
+      n_copies = args.camera isa SCMOSCamera ? 10 : 6
+      memory_required = sizeof(imagestack) * n_copies
+
+      if memory_required <= max_free_mem
+          # If the image stack fits in memory, perform the operation on the whole stack
+          filtered_stack = dog_filter(imagestack, args)
+          coords = findlocalmax(filtered_stack, kernelsize; minval=args.minval, use_gpu=args.use_gpu)
+      else
+          # If the image stack is too big, split it into smaller batches and process each batch separately
+          memory_required_per_frame = size(imagestack, 1)*size(imagestack, 2) * sizeof(eltype(imagestack)) * n_copies
+          batch_size = max(1, Int(floor(max_free_mem / memory_required_per_frame)))
+
+          n_images = size(imagestack, 4)
+          n_batches = Int(ceil(n_images / batch_size))
+
+          coords = Vector{Matrix{Float32}}(undef, 0)
+
+          for i in 1:n_batches
+              start_idx = (i-1)*batch_size + 1
+              end_idx = min(i*batch_size, n_images)
+              batch = imagestack[:, :, :, start_idx:end_idx]
+              filtered_batch = dog_filter(batch, args)
+              coords_batch = findlocalmax(filtered_batch, kernelsize; minval=args.minval, use_gpu=args.use_gpu)
+
+              # Offset frame indices for batched processing
+              # findlocalmax returns frame indices 1:batch_size, but we need actual frame numbers
+              frame_offset = start_idx - 1
+              for coord_matrix in coords_batch
+                  coord_matrix[:, 3] .+= frame_offset
+              end
+
+              append!(coords, coords_batch)
+
+              # Release batch memory before next iteration
+              filtered_batch = nothing
+              batch = nothing
+              GC.gc(false)  # Non-full GC to release recent allocations
+          end
+      end
   end
-  
+
   maxcoords = removeoverlap(coords, args)
 
   # Ensure imagestack is on CPU for box extraction (uses scalar indexing)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -288,6 +288,8 @@ function _getboxes_impl(args::GetBoxesArgs)
               CUDA.synchronize()
           catch e
               @warn "GPU processing failed, falling back to CPU" exception=e
+              GC.gc(false)
+              CUDA.reclaim()
               device_id = -1
               actual_backend = :cpu
               args.use_gpu = false

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -136,6 +136,72 @@ function getboxes(imagestack::AbstractArray{<:Real}, camera::Union{AbstractCamer
 end
 
 """
+    _process_with_batching(imagestack, args, kernelsize, max_free_mem; use_gpu, batch_cleanup=nothing)
+
+Process imagestack with memory-aware batching. Handles both single-batch (fits in memory)
+and multi-batch (too large) cases.
+
+Returns `(coords, batch_size, n_batches, memory_per_batch)`.
+
+# Arguments
+- `imagestack`: 4D image stack (ny, nx, 1, nframes)
+- `args`: GetBoxesArgs with filter parameters
+- `kernelsize`: Kernel size for local max detection
+- `max_free_mem`: Available memory in bytes
+- `use_gpu`: Whether to use GPU for processing
+- `batch_cleanup`: Optional function called after each batch (e.g., for GC)
+"""
+function _process_with_batching(imagestack, args, kernelsize, max_free_mem;
+                                 use_gpu::Bool, batch_cleanup::Union{Function,Nothing}=nothing)
+    # Memory multiplier: 6x for standard DoG, 10x for variance-weighted sCMOS
+    n_copies = args.camera isa SCMOSCamera ? 10 : 6
+    memory_required = sizeof(imagestack) * n_copies
+
+    if memory_required <= max_free_mem
+        # Single batch: process whole stack
+        filtered_stack = dog_filter(imagestack, args)
+        coords = findlocalmax(filtered_stack, kernelsize; minval=args.minval, use_gpu=use_gpu)
+        batch_size = size(imagestack, 4)
+        n_batches = 1
+        memory_per_batch = memory_required
+    else
+        # Multi-batch: split into smaller chunks
+        memory_per_frame = size(imagestack, 1) * size(imagestack, 2) * sizeof(eltype(imagestack)) * n_copies
+        batch_size = max(1, Int(floor(max_free_mem / memory_per_frame)))
+        n_images = size(imagestack, 4)
+        n_batches = Int(ceil(n_images / batch_size))
+        memory_per_batch = batch_size * memory_per_frame
+
+        coords = Vector{Matrix{Float32}}(undef, 0)
+
+        for i in 1:n_batches
+            start_idx = (i - 1) * batch_size + 1
+            end_idx = min(i * batch_size, n_images)
+            batch = imagestack[:, :, :, start_idx:end_idx]
+            filtered_batch = dog_filter(batch, args)
+            coords_batch = findlocalmax(filtered_batch, kernelsize; minval=args.minval, use_gpu=use_gpu)
+
+            # Offset frame indices to actual frame numbers
+            frame_offset = start_idx - 1
+            for coord_matrix in coords_batch
+                coord_matrix[:, 3] .+= frame_offset
+            end
+
+            append!(coords, coords_batch)
+
+            # Optional cleanup between batches (e.g., GC for CPU path)
+            if batch_cleanup !== nothing
+                filtered_batch = nothing
+                batch = nothing
+                batch_cleanup()
+            end
+        end
+    end
+
+    return coords, batch_size, n_batches, memory_per_batch
+end
+
+"""
     _getboxes_impl(args::GetBoxesArgs)
 
 Internal implementation of getboxes that does the actual work.
@@ -168,111 +234,23 @@ function _getboxes_impl(args::GetBoxesArgs)
   memory_per_batch = 0
 
   if args.use_gpu
-      # Find and switch to the GPU with most free memory
+      # GPU path
       find_best_gpu()
-      device_id = Int(CUDA.device().handle)  # 0-based GPU device ID
+      device_id = Int(CUDA.device().handle)
       max_free_mem = CUDA.free_memory()
 
-      # Check the size of the image stack
-      # Memory multiplier for peak GPU usage during processing:
-      # Standard DoG: input + small_blurred + large_blurred + output = 4x peak
-      # LocalMax: filtered_stack + maxpooled + broadcast temps = 3x peak
-      # Variance-weighted (SCMOSCamera): needs MORE memory because:
-      #   - Input copy to GPU: 1x
-      #   - filtered_small output: 1x
-      #   - filtered_large output: 1x
-      #   - DoG result: 1x
-      #   - LocalMax temporaries: 2x
-      #   - GC timing margin: 2x
-      # Using 6x for standard, 10x for variance-weighted sCMOS path
-      n_copies = args.camera isa SCMOSCamera ? 10 : 6
-      memory_required = sizeof(imagestack) * n_copies
-
-      if memory_required <= max_free_mem
-          # If the image stack fits in memory, perform the operation on the whole stack
-          filtered_stack = dog_filter(imagestack, args)
-          coords = findlocalmax(filtered_stack, kernelsize; minval=args.minval, use_gpu=args.use_gpu)
-          # Track batch info for single-batch case
-          batch_size = size(imagestack, 4)
-          n_batches = 1
-          memory_per_batch = memory_required
-      else
-          # If the image stack is too big, split it into smaller batches and process each batch separately
-          memory_required_per_frame = size(imagestack, 1)*size(imagestack, 2) * sizeof(eltype(imagestack)) * n_copies
-          batch_size = max(1, Int(floor(max_free_mem / memory_required_per_frame)))
-
-          n_images = size(imagestack, 4)
-          n_batches = Int(ceil(n_images / batch_size))
-          memory_per_batch = batch_size * memory_required_per_frame
-
-          coords = Vector{Matrix{Float32}}(undef, 0)
-
-          for i in 1:n_batches
-              start_idx = (i-1)*batch_size + 1
-              end_idx = min(i*batch_size, n_images)
-              batch = imagestack[:, :,:, start_idx:end_idx]
-              filtered_batch = dog_filter(batch, args)
-              coords_batch = findlocalmax(filtered_batch, kernelsize; minval=args.minval, use_gpu=args.use_gpu)
-
-              # Offset frame indices for batched processing
-              # findlocalmax returns frame indices 1:batch_size, but we need actual frame numbers
-              frame_offset = start_idx - 1
-              for coord_matrix in coords_batch
-                  coord_matrix[:, 3] .+= frame_offset
-              end
-
-              append!(coords, coords_batch)
-          end
-      end
+      coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
+          imagestack, args, kernelsize, max_free_mem; use_gpu=true)
 
       CUDA.synchronize()
   else
-      # CPU path with memory-aware batching (mirrors GPU batching logic)
+      # CPU path with GC cleanup between batches
       max_free_mem = Sys.free_memory()
-      n_copies = args.camera isa SCMOSCamera ? 10 : 6
-      memory_required = sizeof(imagestack) * n_copies
 
-      if memory_required <= max_free_mem
-          # If the image stack fits in memory, perform the operation on the whole stack
-          filtered_stack = dog_filter(imagestack, args)
-          coords = findlocalmax(filtered_stack, kernelsize; minval=args.minval, use_gpu=args.use_gpu)
-          # Track batch info for single-batch case
-          batch_size = size(imagestack, 4)
-          n_batches = 1
-          memory_per_batch = memory_required
-      else
-          # If the image stack is too big, split it into smaller batches and process each batch separately
-          memory_required_per_frame = size(imagestack, 1)*size(imagestack, 2) * sizeof(eltype(imagestack)) * n_copies
-          batch_size = max(1, Int(floor(max_free_mem / memory_required_per_frame)))
-
-          n_images = size(imagestack, 4)
-          n_batches = Int(ceil(n_images / batch_size))
-          memory_per_batch = batch_size * memory_required_per_frame
-
-          coords = Vector{Matrix{Float32}}(undef, 0)
-
-          for i in 1:n_batches
-              start_idx = (i-1)*batch_size + 1
-              end_idx = min(i*batch_size, n_images)
-              batch = imagestack[:, :, :, start_idx:end_idx]
-              filtered_batch = dog_filter(batch, args)
-              coords_batch = findlocalmax(filtered_batch, kernelsize; minval=args.minval, use_gpu=args.use_gpu)
-
-              # Offset frame indices for batched processing
-              # findlocalmax returns frame indices 1:batch_size, but we need actual frame numbers
-              frame_offset = start_idx - 1
-              for coord_matrix in coords_batch
-                  coord_matrix[:, 3] .+= frame_offset
-              end
-
-              append!(coords, coords_batch)
-
-              # Release batch memory before next iteration
-              filtered_batch = nothing
-              batch = nothing
-              GC.gc(false)  # Non-full GC to release recent allocations
-          end
-      end
+      coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
+          imagestack, args, kernelsize, max_free_mem;
+          use_gpu=false,
+          batch_cleanup=() -> GC.gc(false))
   end
 
   maxcoords = removeoverlap(coords, args)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -126,13 +126,66 @@ for roi in roi_batch
 end
 ```
 """
-function getboxes(imagestack::AbstractArray{<:Real}, camera::Union{AbstractCamera,Nothing}=nothing; kwargs...)
+# Config-based calling convention (primary)
+function getboxes(imagestack::AbstractArray{<:Real}, camera::Union{AbstractCamera,Nothing}, config::BoxerConfig;
+                  on_wait::Union{Function,Nothing}=nothing)
   # Convert to Float32 for type stability throughout pipeline
   imagestack_f32 = imagestack isa AbstractArray{Float32} ? imagestack : Float32.(imagestack)
 
-  # Create args with camera
-  args = GetBoxesArgs(; imagestack=imagestack_f32, camera=camera, kwargs...)
+  # Create args from config
+  args = GetBoxesArgs(;
+      imagestack=imagestack_f32,
+      camera=camera,
+      boxsize=config.boxsize,
+      overlap=config.overlap,
+      psf_sigma=config.psf_sigma,
+      min_photons=config.min_photons,
+      sigma_small=config.psf_sigma === nothing ? config.sigma_small : nothing,
+      sigma_large=config.psf_sigma === nothing ? config.sigma_large : nothing,
+      minval=config.psf_sigma === nothing ? config.minval : nothing,
+      backend=config.backend,
+      auto_timeout=config.auto_timeout,
+      gpu_timeout=config.gpu_timeout,
+      on_wait=on_wait
+  )
   return _getboxes_impl(args)
+end
+
+# Kwargs calling convention (forwards to Config form)
+function getboxes(imagestack::AbstractArray{<:Real}, camera::Union{AbstractCamera,Nothing}=nothing;
+                  psf_sigma::Union{Real,Nothing}=nothing,
+                  min_photons::Real=500.0,
+                  sigma_small::Union{Real,Nothing}=nothing,
+                  sigma_large::Union{Real,Nothing}=nothing,
+                  minval::Union{Real,Nothing}=nothing,
+                  boxsize::Int=7,
+                  overlap::Real=2.0,
+                  backend::Symbol=:auto,
+                  auto_timeout::Real=30.0,
+                  gpu_timeout::Real=Inf,
+                  on_wait::Union{Function,Nothing}=nothing,
+                  use_gpu::Union{Bool,Nothing}=nothing)  # Deprecated
+  # Handle deprecated use_gpu
+  actual_backend = backend
+  if use_gpu !== nothing
+      actual_backend = use_gpu ? :auto : :cpu
+  end
+
+  # Build config from kwargs
+  config = BoxerConfig(
+      psf_sigma=psf_sigma === nothing ? nothing : Float64(psf_sigma),
+      min_photons=Float64(min_photons),
+      sigma_small=Float64(sigma_small === nothing ? 1.0 : sigma_small),
+      sigma_large=Float64(sigma_large === nothing ? 2.0 : sigma_large),
+      minval=Float64(minval === nothing ? 0.0 : minval),
+      boxsize=boxsize,
+      overlap=Float64(overlap),
+      backend=actual_backend,
+      auto_timeout=Float64(auto_timeout),
+      gpu_timeout=Float64(gpu_timeout)
+  )
+
+  return getboxes(imagestack, camera, config; on_wait=on_wait)
 end
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,8 +1,8 @@
 """
-    getboxes(imagestack, camera=nothing; kwargs...) -> ROIBatch
+    getboxes(imagestack, camera=nothing; kwargs...) -> (ROIBatch, BoxesInfo)
 
 Detect particles/blobs in a multidimensional image stack and return
-ROI batch with location tracking.
+ROI batch with location tracking and processing metadata.
 
 # Arguments
 - `imagestack::AbstractArray{<:Real}`: The input image stack. Should be 2D or 3D.
@@ -37,6 +37,8 @@ Note: If `psf_sigma` is provided, it overrides sigma_small/sigma_large/minval.
 - `use_gpu::Bool`: DEPRECATED - use `backend` instead. If provided, `true` maps to `:auto`, `false` to `:cpu`.
 
 # Returns
+Tuple of `(ROIBatch, BoxesInfo)`:
+
 `ROIBatch` with the following fields:
 - `data`: ROI stack (boxsize × boxsize × n_rois) containing image patches
 - `x_corners`: Vector of x (column) corner positions in camera coordinates
@@ -44,6 +46,11 @@ Note: If `psf_sigma` is provided, it overrides sigma_small/sigma_large/minval.
 - `frame_indices`: Vector of frame indices for each ROI
 - `camera`: Camera object (provided or default IdealCamera)
 - `roi_size`: Size of each ROI (square)
+
+`BoxesInfo` with the following fields:
+- `backend`: Compute backend used (:gpu or :cpu)
+- `elapsed_ns`: Wall time in nanoseconds
+- `device_id`: GPU device ID (0-based), or -1 for CPU
 
 # Details on filtering
 
@@ -87,7 +94,7 @@ out around each maximum, excluding overlaps.
 # Recommended: PSF-aware detection with physical units
 camera = IdealCamera(1:256, 1:256, 0.1f0)  # 256×256 pixels, 100nm pixel size
 
-roi_batch = getboxes(imagestack, camera;
+(roi_batch, info) = getboxes(imagestack, camera;
     psf_sigma = 0.13,              # PSF sigma in microns (physical units)
     min_photons = 500.0,           # Detect emitters with ≥500 photons
     boxsize = 11)
@@ -98,8 +105,12 @@ x_corners = roi_batch.x_corners    # x (col) positions
 y_corners = roi_batch.y_corners    # y (row) positions
 frames = roi_batch.frame_indices
 
+# Check processing info
+println("Backend: ", info.backend)
+println("Elapsed: ", info.elapsed_ns / 1e6, " ms")
+
 # Advanced: Direct control over filter parameters
-roi_batch = getboxes(imagestack;
+(roi_batch, info) = getboxes(imagestack;
     sigma_small = 1.5,  # Custom small Gaussian sigma
     sigma_large = 3.0,  # Custom large Gaussian sigma
     minval = 10.0)      # Custom intensity threshold
@@ -126,6 +137,7 @@ end
 Internal implementation of getboxes that does the actual work.
 """
 function _getboxes_impl(args::GetBoxesArgs)
+  start_ns = time_ns()
 
   imagestack = reshape_for_flux(args.imagestack)
 
@@ -145,9 +157,13 @@ function _getboxes_impl(args::GetBoxesArgs)
 
   args.use_gpu = (actual_backend == :gpu)
 
+  # Track device for BoxesInfo
+  device_id = -1  # CPU default
+
   if args.use_gpu
       # Find and switch to the GPU with most free memory
       find_best_gpu()
+      device_id = Int(CUDA.device().handle)  # 0-based GPU device ID
       max_free_mem = CUDA.free_memory()
 
       # Check the size of the image stack
@@ -236,7 +252,11 @@ function _getboxes_impl(args::GetBoxesArgs)
     )
   end
 
-  return ROIBatch(boxstack, x_corners, y_corners, frame_indices, camera)
+  roi_batch = ROIBatch(boxstack, x_corners, y_corners, frame_indices, camera)
+  elapsed_ns = time_ns() - start_ns
+  info = BoxesInfo(actual_backend, elapsed_ns, device_id)
+
+  return (roi_batch, info)
 end
 
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -260,76 +260,63 @@ function _getboxes_impl(args::GetBoxesArgs)
   kernelsize = Int(floor(args.boxsize - args.overlap))
   kernelsize = max(minkernelsize, kernelsize)
 
-  # Determine backend with memory waiting
   # Estimate memory needed for at least 1 frame (minimum batch)
   nrows, ncols = size(imagestack, 1), size(imagestack, 2)
   min_memory_needed = estimate_gpu_memory_per_frame(nrows, ncols, args.camera)
 
-  # select_backend handles NVML polling + device selection (Layer 1)
-  gpu_start = time()
-  actual_backend, device_id = select_backend(args.backend, min_memory_needed;
-      auto_timeout = args.auto_timeout,
-      gpu_timeout = args.gpu_timeout,
-      on_wait = args.on_wait)
-
-  args.use_gpu = (actual_backend == :gpu)
-
-  # Track batch info for BoxesInfo
+  # Track results
+  actual_backend = :cpu
+  device_id = -1
   batch_size = 0
   n_batches = 0
   memory_per_batch = 0
+  gpu_succeeded = false
 
-  if args.use_gpu
-      # GPU path - Layer 2: runtime try/catch for :auto mode
-      if args.backend == :auto
-          gpu_succeeded = false
-          while !gpu_succeeded
-              try
-                  max_free_mem = CUDA.free_memory()
-                  coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
-                      imagestack, args, kernelsize, max_free_mem; use_gpu=true)
-                  CUDA.synchronize()
-                  gpu_succeeded = true
-              catch e
-                  @warn "GPU processing failed, releasing memory and retrying" exception=e
-                  GC.gc(false)
-                  CUDA.reclaim()
+  if args.backend != :cpu && has_cuda()
+      # GPU path: unified retry loop for :auto and :gpu
+      # Handles all failure modes: no free memory, TOCTOU context race, runtime OOM
+      timeout = args.backend == :auto ? args.auto_timeout : args.gpu_timeout
+      deadline = time() + timeout
 
-                  remaining = args.auto_timeout - (time() - gpu_start)
-                  if remaining <= 0
-                      @warn "GPU retry timeout expired, falling back to CPU"
-                      device_id = -1
-                      actual_backend = :cpu
-                      args.use_gpu = false
-                      break
-                  end
+      while !gpu_succeeded && time() < deadline
+          remaining = max(0.0, deadline - time())
 
-                  # Re-poll NVML with remaining timeout budget
-                  available, new_device_id = poll_gpu_nvml(min_memory_needed;
-                      timeout=remaining, on_wait=args.on_wait)
-                  if available
-                      CUDA.device!(new_device_id)
-                      device_id = new_device_id
-                  else
-                      @warn "No GPU available after retry, falling back to CPU"
-                      device_id = -1
-                      actual_backend = :cpu
-                      args.use_gpu = false
-                      break
-                  end
-              end
+          # Poll NVML for available GPU
+          available, dev_id = poll_gpu_nvml(min_memory_needed;
+              timeout=remaining, on_wait=args.on_wait)
+          !available && break
+
+          try
+              CUDA.device!(dev_id)
+              max_free_mem = CUDA.free_memory()
+              coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
+                  imagestack, args, kernelsize, max_free_mem; use_gpu=true)
+              CUDA.synchronize()
+              device_id = dev_id
+              actual_backend = :gpu
+              gpu_succeeded = true
+          catch e
+              @warn "GPU failed, releasing memory and retrying" exception=e
+              GC.gc(false)
+              CUDA.reclaim()
+              # loop back to poll_gpu_nvml
           end
-      else
-          # :gpu mode - no fallback, let errors propagate
-          max_free_mem = CUDA.free_memory()
-          coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
-              imagestack, args, kernelsize, max_free_mem; use_gpu=true)
-          CUDA.synchronize()
       end
+
+      if !gpu_succeeded
+          if args.backend == :gpu
+              error("GPU processing failed after $(timeout)s. " *
+                    "Required: $(Base.format_bytes(min_memory_needed))")
+          else
+              @warn "GPU unavailable after $(timeout)s, using CPU"
+          end
+      end
+  elseif args.backend == :gpu
+      error("GPU backend requested but CUDA is not functional")
   end
 
-  if !args.use_gpu
-      # CPU path with GC cleanup between batches
+  if !gpu_succeeded
+      # CPU path
       max_free_mem = Sys.free_memory()
       coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
           imagestack, args, kernelsize, max_free_mem;

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -287,16 +287,43 @@ function _getboxes_impl(args::GetBoxesArgs)
   memory_per_batch = 0
 
   if args.use_gpu
-      # GPU path
-      find_best_gpu()
-      device_id = Int(CUDA.device().handle)
-      max_free_mem = CUDA.free_memory()
+      # GPU path - wrap in fallback for :auto mode
+      gpu_failed = false
+      if args.backend == :auto
+          try
+              find_best_gpu()
+              device_id = Int(CUDA.device().handle)
+              max_free_mem = CUDA.free_memory()
 
-      coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
-          imagestack, args, kernelsize, max_free_mem; use_gpu=true)
+              coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
+                  imagestack, args, kernelsize, max_free_mem; use_gpu=true)
 
-      CUDA.synchronize()
-  else
+              CUDA.synchronize()
+          catch e
+              @warn "GPU processing failed, falling back to CPU" exception=e
+              gpu_failed = true
+              device_id = -1
+              actual_backend = :cpu
+              args.use_gpu = false
+          end
+      else
+          # :gpu mode - no fallback, let errors propagate
+          find_best_gpu()
+          device_id = Int(CUDA.device().handle)
+          max_free_mem = CUDA.free_memory()
+
+          coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
+              imagestack, args, kernelsize, max_free_mem; use_gpu=true)
+
+          CUDA.synchronize()
+      end
+
+      if gpu_failed
+          # Fall through to CPU path
+      end
+  end
+
+  if !args.use_gpu
       # CPU path with GC cleanup between batches
       max_free_mem = Sys.free_memory()
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -292,6 +292,8 @@ function _getboxes_impl(args::GetBoxesArgs)
               coords, batch_size, n_batches, memory_per_batch = _process_with_batching(
                   imagestack, args, kernelsize, max_free_mem; use_gpu=true)
               CUDA.synchronize()
+              GC.gc(false)
+              CUDA.reclaim()
               device_id = dev_id
               actual_backend = :gpu
               gpu_succeeded = true

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -157,8 +157,11 @@ function _getboxes_impl(args::GetBoxesArgs)
 
   args.use_gpu = (actual_backend == :gpu)
 
-  # Track device for BoxesInfo
+  # Track device and batch info for BoxesInfo
   device_id = -1  # CPU default
+  batch_size = 0
+  n_batches = 0
+  memory_per_batch = 0
 
   if args.use_gpu
       # Find and switch to the GPU with most free memory
@@ -185,15 +188,19 @@ function _getboxes_impl(args::GetBoxesArgs)
           # If the image stack fits in memory, perform the operation on the whole stack
           filtered_stack = dog_filter(imagestack, args)
           coords = findlocalmax(filtered_stack, kernelsize; minval=args.minval, use_gpu=args.use_gpu)
+          # Track batch info for single-batch case
+          batch_size = size(imagestack, 4)
+          n_batches = 1
+          memory_per_batch = memory_required
       else
           # If the image stack is too big, split it into smaller batches and process each batch separately
           memory_required_per_frame = size(imagestack, 1)*size(imagestack, 2) * sizeof(eltype(imagestack)) * n_copies
-          # println("Memory required per frame: ", memory_required_per_frame / 1024^3, " GB\n")
           batch_size = max(1, Int(floor(max_free_mem / memory_required_per_frame)))
 
           n_images = size(imagestack, 4)
           n_batches = Int(ceil(n_images / batch_size))
-          
+          memory_per_batch = batch_size * memory_required_per_frame
+
           coords = Vector{Matrix{Float32}}(undef, 0)
 
           for i in 1:n_batches
@@ -225,6 +232,10 @@ function _getboxes_impl(args::GetBoxesArgs)
           # If the image stack fits in memory, perform the operation on the whole stack
           filtered_stack = dog_filter(imagestack, args)
           coords = findlocalmax(filtered_stack, kernelsize; minval=args.minval, use_gpu=args.use_gpu)
+          # Track batch info for single-batch case
+          batch_size = size(imagestack, 4)
+          n_batches = 1
+          memory_per_batch = memory_required
       else
           # If the image stack is too big, split it into smaller batches and process each batch separately
           memory_required_per_frame = size(imagestack, 1)*size(imagestack, 2) * sizeof(eltype(imagestack)) * n_copies
@@ -232,6 +243,7 @@ function _getboxes_impl(args::GetBoxesArgs)
 
           n_images = size(imagestack, 4)
           n_batches = Int(ceil(n_images / batch_size))
+          memory_per_batch = batch_size * memory_required_per_frame
 
           coords = Vector{Matrix{Float32}}(undef, 0)
 
@@ -293,7 +305,7 @@ function _getboxes_impl(args::GetBoxesArgs)
 
   roi_batch = ROIBatch(boxstack, x_corners, y_corners, frame_indices, camera)
   elapsed_ns = time_ns() - start_ns
-  info = BoxesInfo(actual_backend, elapsed_ns, device_id)
+  info = BoxesInfo(actual_backend, elapsed_ns, device_id, n_rois, batch_size, n_batches, memory_per_batch)
 
   return (roi_batch, info)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,73 @@
 """
+    BoxerConfig
+
+Configuration for ROI detection via getboxes().
+
+Use either PSF-aware interface (psf_sigma + min_photons) or advanced interface
+(sigma_small + sigma_large + minval). PSF-aware is recommended.
+
+# Fields
+
+## PSF-Aware Interface (Recommended)
+- `psf_sigma::Union{Float64,Nothing}`: PSF sigma in microns (e.g., 0.13 for 130nm PSF).
+  Requires camera for pixel conversion. When set, overrides sigma_small/sigma_large/minval.
+- `min_photons::Float64`: Minimum photons for detection (default: 500.0)
+
+## Advanced Interface (Direct Control)
+- `sigma_small::Float64`: Small Gaussian sigma in pixels (default: 1.0)
+- `sigma_large::Float64`: Large Gaussian sigma in pixels (default: 2.0)
+- `minval::Float64`: DoG intensity threshold (default: 0.0)
+
+## Box Parameters
+- `boxsize::Int`: ROI box size in pixels (default: 7)
+- `overlap::Float64`: Max overlap between detections in pixels (default: 2.0)
+
+## Backend Parameters
+- `backend::Symbol`: Compute backend :cpu, :gpu, or :auto (default: :auto)
+- `auto_timeout::Float64`: Max wait for GPU in :auto mode before CPU fallback (default: 30.0)
+- `gpu_timeout::Float64`: Max wait for GPU in :gpu mode (default: Inf)
+
+# Examples
+```julia
+# PSF-aware (recommended)
+config = BoxerConfig(psf_sigma=0.13, min_photons=500.0, boxsize=11)
+
+# Advanced (direct control)
+config = BoxerConfig(sigma_small=1.5, sigma_large=3.0, minval=10.0)
+
+# GPU-specific
+config = BoxerConfig(psf_sigma=0.13, backend=:gpu, gpu_timeout=60.0)
+```
+"""
+Base.@kwdef struct BoxerConfig
+    # PSF-aware interface
+    psf_sigma::Union{Float64,Nothing} = nothing
+    min_photons::Float64 = 500.0
+
+    # Advanced interface (direct control)
+    sigma_small::Float64 = 1.0
+    sigma_large::Float64 = 2.0
+    minval::Float64 = 0.0
+
+    # Box parameters
+    boxsize::Int = 7
+    overlap::Float64 = 2.0
+
+    # Backend parameters
+    backend::Symbol = :auto
+    auto_timeout::Float64 = 30.0
+    gpu_timeout::Float64 = Inf
+end
+
+function Base.show(io::IO, config::BoxerConfig)
+    if config.psf_sigma !== nothing
+        print(io, "BoxerConfig(psf_sigma=$(config.psf_sigma), min_photons=$(config.min_photons), boxsize=$(config.boxsize), backend=$(config.backend))")
+    else
+        print(io, "BoxerConfig(σ_small=$(config.sigma_small), σ_large=$(config.sigma_large), minval=$(config.minval), boxsize=$(config.boxsize), backend=$(config.backend))")
+    end
+end
+
+"""
     BoxesInfo
 
 Metadata returned alongside ROIBatch from getboxes().

--- a/src/types.jl
+++ b/src/types.jl
@@ -5,7 +5,7 @@ Metadata returned alongside ROIBatch from getboxes().
 
 # Fields
 - `backend::Symbol`: Compute backend used (:gpu or :cpu)
-- `elapsed_ns::UInt64`: Wall time in nanoseconds
+- `elapsed_s::Float64`: Wall time in seconds
 - `device_id::Int`: GPU device ID (0-based), or -1 for CPU
 - `n_rois::Int`: Number of ROIs detected
 - `batch_size::Int`: Frames per batch during processing
@@ -14,7 +14,7 @@ Metadata returned alongside ROIBatch from getboxes().
 """
 struct BoxesInfo
     backend::Symbol
-    elapsed_ns::UInt64
+    elapsed_s::Float64
     device_id::Int
     n_rois::Int
     batch_size::Int
@@ -23,7 +23,7 @@ struct BoxesInfo
 end
 
 function Base.show(io::IO, info::BoxesInfo)
-    elapsed_ms = info.elapsed_ns / 1e6
+    elapsed_ms = info.elapsed_s * 1000
     mem_kb = info.memory_per_batch / 1024
     mem_str = mem_kb >= 1024 ? "$(round(mem_kb/1024, digits=1)) MB" : "$(round(mem_kb, digits=1)) KB"
     print(io, "BoxesInfo($(info.n_rois) ROIs, $(round(elapsed_ms, digits=1)) ms, $(info.backend), $(info.n_batches) batches × $(info.batch_size), $(mem_str)/batch)")

--- a/src/types.jl
+++ b/src/types.jl
@@ -39,7 +39,7 @@ config = BoxerConfig(sigma_small=1.5, sigma_large=3.0, minval=10.0)
 config = BoxerConfig(psf_sigma=0.13, backend=:gpu, gpu_timeout=60.0)
 ```
 """
-Base.@kwdef struct BoxerConfig
+Base.@kwdef struct BoxerConfig <: AbstractSMLMConfig
     # PSF-aware interface
     psf_sigma::Union{Float64,Nothing} = nothing
     min_photons::Float64 = 500.0
@@ -81,7 +81,7 @@ Metadata returned alongside ROIBatch from getboxes().
 - `n_batches::Int`: Number of batches processed
 - `memory_per_batch::Int`: Estimated memory per batch in bytes
 """
-struct BoxesInfo
+struct BoxesInfo <: AbstractSMLMInfo
     backend::Symbol
     elapsed_s::Float64
     device_id::Int

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,11 +7,26 @@ Metadata returned alongside ROIBatch from getboxes().
 - `backend::Symbol`: Compute backend used (:gpu or :cpu)
 - `elapsed_ns::UInt64`: Wall time in nanoseconds
 - `device_id::Int`: GPU device ID (0-based), or -1 for CPU
+- `n_rois::Int`: Number of ROIs detected
+- `batch_size::Int`: Frames per batch during processing
+- `n_batches::Int`: Number of batches processed
+- `memory_per_batch::Int`: Estimated memory per batch in bytes
 """
 struct BoxesInfo
     backend::Symbol
     elapsed_ns::UInt64
     device_id::Int
+    n_rois::Int
+    batch_size::Int
+    n_batches::Int
+    memory_per_batch::Int
+end
+
+function Base.show(io::IO, info::BoxesInfo)
+    elapsed_ms = info.elapsed_ns / 1e6
+    mem_kb = info.memory_per_batch / 1024
+    mem_str = mem_kb >= 1024 ? "$(round(mem_kb/1024, digits=1)) MB" : "$(round(mem_kb, digits=1)) KB"
+    print(io, "BoxesInfo($(info.n_rois) ROIs, $(round(elapsed_ms, digits=1)) ms, $(info.backend), $(info.n_batches) batches × $(info.batch_size), $(mem_str)/batch)")
 end
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,6 +26,7 @@ Use either PSF-aware interface (psf_sigma + min_photons) or advanced interface
 - `backend::Symbol`: Compute backend :cpu, :gpu, or :auto (default: :auto)
 - `auto_timeout::Float64`: Max wait for GPU in :auto mode before CPU fallback (default: 30.0)
 - `gpu_timeout::Float64`: Max wait for GPU in :gpu mode (default: Inf)
+- `on_wait::Union{Function,Nothing}`: Optional callback `(elapsed, available, required) -> nothing` for GPU wait progress (default: nothing)
 
 # Examples
 ```julia
@@ -57,6 +58,7 @@ Base.@kwdef struct BoxerConfig <: AbstractSMLMConfig
     backend::Symbol = :auto
     auto_timeout::Float64 = 30.0
     gpu_timeout::Float64 = Inf
+    on_wait::Union{Function,Nothing} = nothing
 end
 
 function Base.show(io::IO, config::BoxerConfig)
@@ -220,7 +222,6 @@ When psf_sigma is provided:
 - `camera`: Camera object (IdealCamera or SCMOSCamera)
 - `boxsize::Int`: ROI box size in pixels (default: 7)
 - `overlap::Real`: Maximum overlap between detections in pixels (default: 2.0)
-- `use_gpu::Bool`: Use GPU acceleration (default: true) - DEPRECATED, use backend instead
 - `backend::Symbol`: Compute backend :cpu, :gpu, or :auto (default: :auto)
 - `auto_timeout::Real`: Max wait seconds for :auto mode before CPU fallback (default: 30.0)
 - `gpu_timeout::Real`: Max wait seconds for :gpu mode (default: Inf)
@@ -251,7 +252,6 @@ mutable struct GetBoxesArgs
         sigma_small::Union{Real,Nothing} = nothing,
         sigma_large::Union{Real,Nothing} = nothing,
         minval::Union{Real,Nothing} = nothing,
-        use_gpu::Union{Bool,Nothing} = nothing,
         backend::Symbol = :auto,
         auto_timeout::Real = 30.0,
         gpu_timeout::Real = Inf,
@@ -259,7 +259,7 @@ mutable struct GetBoxesArgs
     )
         # Determine which interface is being used
         if psf_sigma !== nothing
-            # NEW INTERFACE: PSF-aware detection (recommended)
+            # PSF-aware detection (recommended)
             # psf_sigma is in physical units (microns) - convert to pixels
             if camera !== nothing
                 pixel_size_μm = get_pixel_size(camera)
@@ -274,27 +274,20 @@ mutable struct GetBoxesArgs
             effective_gain = get_effective_gain(camera)
             min_val = photons_to_dog_threshold(min_photons, psf_sigma_pixels; effective_gain=effective_gain)
         else
-            # OLD INTERFACE: Direct control (backward compatible)
+            # Direct control interface
             σ_small = Float32(sigma_small !== nothing ? sigma_small : 1.0)
             σ_large = Float32(sigma_large !== nothing ? sigma_large : 2.0)
             min_val = Float32(minval !== nothing ? minval : 0.0)
         end
 
-        # Handle backwards compatibility: use_gpu overrides backend if explicitly set
-        actual_backend = backend
-        if use_gpu !== nothing
-            actual_backend = use_gpu ? :auto : :cpu
-        end
-
         # Validate backend
-        actual_backend in (:cpu, :gpu, :auto) || error("backend must be :cpu, :gpu, or :auto")
+        backend in (:cpu, :gpu, :auto) || error("backend must be :cpu, :gpu, or :auto")
 
         # use_gpu is determined later in _getboxes_impl based on backend and memory availability
-        # For now, set it based on backend intent (will be refined during processing)
-        initial_use_gpu = actual_backend != :cpu
+        initial_use_gpu = backend != :cpu
 
         new(imagestack, camera, boxsize, Float32(overlap), σ_small, σ_large, min_val,
-            initial_use_gpu, actual_backend, Float64(auto_timeout), Float64(gpu_timeout), on_wait)
+            initial_use_gpu, backend, Float64(auto_timeout), Float64(gpu_timeout), on_wait)
     end
 end
 
@@ -418,7 +411,6 @@ running out of memory.
 - `width::Int`: Image width in pixels
 - `backend::Symbol`: Compute backend :cpu, :gpu, or :auto (default: :auto)
 - `memory_fraction::Real`: Fraction of free memory to use (default: 0.8)
-- `use_gpu::Bool`: DEPRECATED - use backend instead
 
 # Returns
 - Maximum recommended number of frames to load at once
@@ -451,21 +443,14 @@ end
 """
 function recommend_batch_size(height::Int, width::Int;
         backend::Symbol=:auto,
-        use_gpu::Union{Bool,Nothing}=nothing,
         memory_fraction::Real=0.8)
     # Memory multiplier: accounts for all processing stages
     # Matches n_copies in _getboxes_impl for consistency
     n_copies = 6
     bytes_per_frame = height * width * sizeof(Float32) * n_copies
 
-    # Handle backwards compatibility
-    actual_backend = backend
-    if use_gpu !== nothing
-        actual_backend = use_gpu ? :auto : :cpu
-    end
-
     # Determine if GPU should be used
-    use_gpu_actual = actual_backend != :cpu && has_cuda() && CUDA.functional()
+    use_gpu_actual = backend != :cpu && has_cuda() && CUDA.functional()
 
     if use_gpu_actual
         # GPU: find device with most free memory via NVML (no context switch needed)

--- a/src/types.jl
+++ b/src/types.jl
@@ -468,12 +468,11 @@ function recommend_batch_size(height::Int, width::Int;
     use_gpu_actual = actual_backend != :cpu && has_cuda() && CUDA.functional()
 
     if use_gpu_actual
-        # GPU: find device with most free memory
+        # GPU: find device with most free memory via NVML (no context switch needed)
         max_free_mem = 0
         for i in 0:length(CUDA.devices())-1
-            CUDA.device!(i)
-            free_mem = CUDA.free_memory()
-            max_free_mem = max(max_free_mem, free_mem)
+            info = CUDA.NVML.memory_info(CUDA.NVML.Device(i))
+            max_free_mem = max(max_free_mem, info.free)
         end
         available = max_free_mem * memory_fraction
     else

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,20 @@
 """
+    BoxesInfo
+
+Metadata returned alongside ROIBatch from getboxes().
+
+# Fields
+- `backend::Symbol`: Compute backend used (:gpu or :cpu)
+- `elapsed_ns::UInt64`: Wall time in nanoseconds
+- `device_id::Int`: GPU device ID (0-based), or -1 for CPU
+"""
+struct BoxesInfo
+    backend::Symbol
+    elapsed_ns::UInt64
+    device_id::Int
+end
+
+"""
     get_pixel_size(camera::AbstractCamera)
 
 Extract pixel size from camera pixel edges (in microns).

--- a/test/local_gpu_wait_test.jl
+++ b/test/local_gpu_wait_test.jl
@@ -113,13 +113,14 @@ function run_gpu_wait_tests()
         println("\n[5/6] Skipping backend=:gpu test (no CUDA)")
     end
 
-    # Test 6: Backwards compatibility with use_gpu kwarg
-    println("\n[6/6] Testing backwards compatibility (use_gpu=false)...")
+    # Test 6: Explicit backend=:cpu
+    println("\n[6/6] Testing explicit backend=:cpu...")
     try
         (result, info) = getboxes(img, camera;
-            use_gpu=false,
+            backend=:cpu,
             sigma_small=1.5, sigma_large=3.0, minval=0.1)
-        println("      Passed: $(length(result)) ROIs detected (use_gpu=false -> backend=$(info.backend))")
+        @assert info.backend == :cpu "Expected :cpu backend"
+        println("      Passed: $(length(result)) ROIs detected (backend=$(info.backend))")
     catch e
         println("      FAILED: $e")
         all_passed = false

--- a/test/local_gpu_wait_test.jl
+++ b/test/local_gpu_wait_test.jl
@@ -29,10 +29,10 @@ function run_gpu_wait_tests()
     # Test 1: backend=:cpu should always use CPU
     println("\n[1/6] Testing backend=:cpu...")
     try
-        result = getboxes(img, camera;
+        (result, info) = getboxes(img, camera;
             backend=:cpu,
             sigma_small=1.5, sigma_large=3.0, minval=0.1)
-        println("      Passed: $(length(result)) ROIs detected on CPU")
+        println("      Passed: $(length(result)) ROIs detected on CPU (backend=$(info.backend))")
     catch e
         println("      FAILED: $e")
         all_passed = false
@@ -41,11 +41,11 @@ function run_gpu_wait_tests()
     # Test 2: backend=:auto should work (GPU or CPU fallback)
     println("\n[2/6] Testing backend=:auto...")
     try
-        result = getboxes(img, camera;
+        (result, info) = getboxes(img, camera;
             backend=:auto,
             auto_timeout=5.0,
             sigma_small=1.5, sigma_large=3.0, minval=0.1)
-        println("      Passed: $(length(result)) ROIs detected")
+        println("      Passed: $(length(result)) ROIs detected (backend=$(info.backend))")
     catch e
         println("      FAILED: $e")
         all_passed = false
@@ -61,11 +61,11 @@ function run_gpu_wait_tests()
         # With impossibly short timeout, should either:
         # a) Fall back to CPU with warning (if GPU memory check takes time)
         # b) Still use GPU (if memory was immediately available)
-        result = getboxes(large_img, large_camera;
+        (result, info) = getboxes(large_img, large_camera;
             backend=:auto,
             auto_timeout=0.001,  # Impossibly short
             sigma_small=1.5, sigma_large=3.0, minval=0.1)
-        println("      Passed: $(length(result)) ROIs (GPU memory was immediately available)")
+        println("      Passed: $(length(result)) ROIs (backend=$(info.backend))")
     catch e
         println("      Note: $e")
         all_passed = false
@@ -81,7 +81,7 @@ function run_gpu_wait_tests()
     end
 
     try
-        result = getboxes(img, camera;
+        (result, info) = getboxes(img, camera;
             backend=:auto,
             auto_timeout=2.0,
             on_wait=on_wait_cb,
@@ -100,11 +100,11 @@ function run_gpu_wait_tests()
     if CUDA.functional()
         println("\n[5/6] Testing backend=:gpu (GPU required)...")
         try
-            result = getboxes(img, camera;
+            (result, info) = getboxes(img, camera;
                 backend=:gpu,
                 gpu_timeout=10.0,
                 sigma_small=1.5, sigma_large=3.0, minval=0.1)
-            println("      Passed: $(length(result)) ROIs detected on GPU")
+            println("      Passed: $(length(result)) ROIs detected on GPU (device=$(info.device_id))")
         catch e
             println("      FAILED: $e")
             all_passed = false
@@ -116,10 +116,10 @@ function run_gpu_wait_tests()
     # Test 6: Backwards compatibility with use_gpu kwarg
     println("\n[6/6] Testing backwards compatibility (use_gpu=false)...")
     try
-        result = getboxes(img, camera;
+        (result, info) = getboxes(img, camera;
             use_gpu=false,
             sigma_small=1.5, sigma_large=3.0, minval=0.1)
-        println("      Passed: $(length(result)) ROIs detected (use_gpu=false -> CPU)")
+        println("      Passed: $(length(result)) ROIs detected (use_gpu=false -> backend=$(info.backend))")
     catch e
         println("      FAILED: $e")
         all_passed = false
@@ -196,13 +196,13 @@ function test_memory_pressure_wait()
 
         println("\nRunning getboxes with memory pressure...")
         try
-            result = getboxes(img, camera;
+            (result, info) = getboxes(img, camera;
                 backend=:auto,
                 auto_timeout=3.0,
                 on_wait=on_wait_cb,
                 sigma_small=1.5, sigma_large=3.0, minval=0.1)
 
-            println("Result: $(length(result)) ROIs")
+            println("Result: $(length(result)) ROIs (backend=$(info.backend))")
 
             if wait_triggered[]
                 println("Wait callback WAS triggered - waiting behavior verified!")

--- a/test/local_performance_benchmark.jl
+++ b/test/local_performance_benchmark.jl
@@ -80,7 +80,7 @@ Benchmark getboxes with warmup and multiple runs.
 function benchmark_getboxes(image, camera; use_gpu=false, nwarmup=WARMUP_ITERATIONS, nruns=BENCHMARK_RUNS)
     # Warmup
     for _ in 1:nwarmup
-        result = getboxes(image, camera;
+        (result, _) = getboxes(image, camera;
             boxsize=7,
             overlap=3.0,
             sigma_small=1.0,
@@ -101,7 +101,7 @@ function benchmark_getboxes(image, camera; use_gpu=false, nwarmup=WARMUP_ITERATI
         end
 
         t0 = time()
-        result = getboxes(image, camera;
+        (result, _) = getboxes(image, camera;
             boxsize=7,
             overlap=3.0,
             sigma_small=1.0,

--- a/test/local_performance_benchmark.jl
+++ b/test/local_performance_benchmark.jl
@@ -73,11 +73,11 @@ function create_synthetic_image(nx, ny, nframes, nspots_per_frame; sigma=2.0, in
 end
 
 """
-    benchmark_getboxes(image, camera; use_gpu=false, nwarmup=2, nruns=5)
+    benchmark_getboxes(image, camera; backend=:cpu, nwarmup=2, nruns=5)
 
 Benchmark getboxes with warmup and multiple runs.
 """
-function benchmark_getboxes(image, camera; use_gpu=false, nwarmup=WARMUP_ITERATIONS, nruns=BENCHMARK_RUNS)
+function benchmark_getboxes(image, camera; backend::Symbol=:cpu, nwarmup=WARMUP_ITERATIONS, nruns=BENCHMARK_RUNS)
     # Warmup
     for _ in 1:nwarmup
         (result, _) = getboxes(image, camera;
@@ -86,7 +86,7 @@ function benchmark_getboxes(image, camera; use_gpu=false, nwarmup=WARMUP_ITERATI
             sigma_small=1.0,
             sigma_large=2.0,
             minval=5.0,
-            use_gpu=use_gpu
+            backend=backend
         )
     end
 
@@ -96,7 +96,7 @@ function benchmark_getboxes(image, camera; use_gpu=false, nwarmup=WARMUP_ITERATI
 
     for _ in 1:nruns
         GC.gc()  # Force garbage collection
-        if CUDA.functional() && use_gpu
+        if CUDA.functional() && backend != :cpu
             CUDA.reclaim()  # Reclaim GPU memory
         end
 
@@ -107,7 +107,7 @@ function benchmark_getboxes(image, camera; use_gpu=false, nwarmup=WARMUP_ITERATI
             sigma_small=1.0,
             sigma_large=2.0,
             minval=5.0,
-            use_gpu=use_gpu
+            backend=backend
         )
         t1 = time()
 
@@ -145,12 +145,12 @@ function run_single_benchmark(config::BenchmarkConfig, has_cuda::Bool)
     end
 
     # CPU benchmark
-    cpu_time, cpu_found = benchmark_getboxes(image, camera; use_gpu=false)
+    cpu_time, cpu_found = benchmark_getboxes(image, camera; backend=:cpu)
     cpu_throughput = config.nframes / cpu_time
 
     # GPU benchmark
     if has_cuda
-        gpu_time, gpu_found = benchmark_getboxes(image, camera; use_gpu=true)
+        gpu_time, gpu_found = benchmark_getboxes(image, camera; backend=:auto)
         gpu_throughput = config.nframes / gpu_time
         speedup = cpu_time / gpu_time
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -292,6 +292,41 @@ using Test
         @test info.elapsed_s > 0
     end
 
+    @testset "BoxerConfig calling convention" begin
+        # Test config-based calling
+        image = zeros(Float32, 100, 100)
+        image[50, 50] = 1000.0
+
+        camera = IdealCamera(1:101, 1:101, 0.1f0)
+
+        # PSF-aware config
+        config_psf = BoxerConfig(psf_sigma=0.13, min_photons=500.0, boxsize=11)
+        @test config_psf isa BoxerConfig
+        @test config_psf.psf_sigma == 0.13
+        @test config_psf.boxsize == 11
+
+        (roi_batch, info) = getboxes(image, camera, config_psf)
+        @test length(roi_batch) >= 1
+        @test info isa BoxesInfo
+
+        # Advanced config (sigma_small/sigma_large)
+        config_adv = BoxerConfig(sigma_small=1.5, sigma_large=3.0, minval=0.1, boxsize=7, backend=:cpu)
+        @test config_adv.psf_sigma === nothing
+        @test config_adv.sigma_small == 1.5
+        @test config_adv.backend == :cpu
+
+        image2 = zeros(Float32, 100, 100)
+        image2[20, 50] = 10
+
+        (roi_batch2, info2) = getboxes(image2, nothing, config_adv)
+        @test info2.backend == :cpu
+
+        # Kwargs should produce same result as config
+        (roi_batch3, info3) = getboxes(image2;
+            sigma_small=1.5, sigma_large=3.0, minval=0.1, boxsize=7, backend=:cpu)
+        @test length(roi_batch2) == length(roi_batch3)
+    end
+
     @testset "sCMOS variance-weighted detection (per-pixel)" begin
         # Create image with two spots of equal intensity
         image = zeros(Float32, 100, 100)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ using Test
         image[30, 60] = 10
 
         # Get boxes without camera (positional interface)
-        roi_batch = getboxes(image;
+        (roi_batch, info) = getboxes(image;
             boxsize=5,
             overlap=3.0,
             sigma_small=1.0,
@@ -30,6 +30,12 @@ using Test
         @test hasfield(typeof(roi_batch), :y_corners)
         @test hasfield(typeof(roi_batch), :frame_indices)
         @test hasfield(typeof(roi_batch), :camera)
+
+        # Test BoxesInfo structure
+        @test info isa BoxesInfo
+        @test info.backend == :cpu
+        @test info.elapsed_ns > 0
+        @test info.device_id == -1  # CPU
 
         # Should detect two peaks
         @test size(roi_batch.data) == (5, 5, 2)
@@ -54,7 +60,7 @@ using Test
         image[20, 50] = 20
         image[21, 51] = 10
 
-        roi_batch = getboxes(image;
+        (roi_batch, info) = getboxes(image;
             boxsize=5,
             overlap=3.0,
             sigma_small=1.0,
@@ -72,6 +78,10 @@ using Test
         @test roi_batch.x_corners[1] == 48  # x (col)
         @test roi_batch.y_corners[1] == 18  # y (row)
         @test roi_batch.frame_indices[1] == 1
+
+        # BoxesInfo should be valid
+        @test info isa BoxesInfo
+        @test info.elapsed_ns > 0
     end
 
     @testset "New API with IdealCamera" begin
@@ -89,7 +99,7 @@ using Test
         )
 
         # Get boxes with camera
-        roi_batch = getboxes(image, camera;
+        (roi_batch, info) = getboxes(image, camera;
             boxsize=5,
             overlap=3.0,
             sigma_small=1.0,
@@ -116,6 +126,10 @@ using Test
         # Check camera is present and correct type
         @test roi_batch.camera isa IdealCamera
         @test roi_batch.camera === camera
+
+        # BoxesInfo should be valid
+        @test info isa BoxesInfo
+        @test info.elapsed_ns > 0
     end
 
     @testset "New API with SCMOSCamera (scalar params)" begin
@@ -135,7 +149,7 @@ using Test
             qe = 0.9f0
         )
 
-        roi_batch = getboxes(image, camera;
+        (roi_batch, info) = getboxes(image, camera;
             boxsize=5,
             overlap=3.0,
             sigma_small=1.0,
@@ -153,6 +167,10 @@ using Test
         @test roi_batch.camera === camera
         @test roi_batch.camera.offset == 100.0f0
         @test roi_batch.camera.gain == 2.0f0
+
+        # BoxesInfo should be valid
+        @test info isa BoxesInfo
+        @test info.elapsed_ns > 0
     end
 
     @testset "Rectangular SCMOSCamera with per-pixel calibration" begin
@@ -223,7 +241,7 @@ using Test
 
         # Use PSF-aware interface with physical units (microns)
         psf_sigma_microns = 0.13f0  # 130nm PSF
-        roi_batch = getboxes(image, camera;
+        (roi_batch, info) = getboxes(image, camera;
             psf_sigma = psf_sigma_microns,  # In microns (auto-converts to pixels)
             min_photons = 500.0,             # Should detect our 1000 photon peak
             boxsize = 11,
@@ -239,8 +257,12 @@ using Test
         @test roi_batch.x_corners[1] == 45  # x (col)
         @test roi_batch.y_corners[1] == 45  # y (row)
 
+        # BoxesInfo should be valid
+        @test info isa BoxesInfo
+        @test info.elapsed_ns > 0
+
         # Test with higher threshold - should not detect
-        roi_batch_high = getboxes(image, camera;
+        (roi_batch_high, _) = getboxes(image, camera;
             psf_sigma = psf_sigma_microns,
             min_photons = 5000.0,  # Way above our peak
             boxsize = 11,
@@ -254,7 +276,7 @@ using Test
         image = zeros(Float32, 100, 100)
         image[20, 50] = 10
 
-        roi_batch = getboxes(image;
+        (roi_batch, info) = getboxes(image;
             boxsize = 5,
             sigma_small = 1.0,
             sigma_large = 2.0,
@@ -264,6 +286,10 @@ using Test
 
         @test length(roi_batch) >= 1
         @test size(roi_batch.data, 3) >= 1
+
+        # BoxesInfo should be valid
+        @test info isa BoxesInfo
+        @test info.elapsed_ns > 0
     end
 
     @testset "sCMOS variance-weighted detection (per-pixel)" begin
@@ -288,7 +314,7 @@ using Test
             qe = 0.9f0
         )
 
-        roi_batch = getboxes(image, camera;
+        (roi_batch, info) = getboxes(image, camera;
             boxsize=7,
             overlap=3.0,
             sigma_small=1.0,
@@ -306,6 +332,10 @@ using Test
         @test roi_batch.camera isa SCMOSCamera
         @test roi_batch.camera.readnoise isa AbstractArray
         @test size(roi_batch.camera.readnoise) == (100, 100)  # Full image readnoise map
+
+        # BoxesInfo should be valid
+        @test info isa BoxesInfo
+        @test info.elapsed_ns > 0
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ using Test
             sigma_small=1.0,
             sigma_large=2.0,
             minval=0.1,
-            use_gpu=false
+            backend=:cpu
         )
 
         # Test ROIBatch structure
@@ -66,7 +66,7 @@ using Test
             sigma_small=1.0,
             sigma_large=2.0,
             minval=0.1,
-            use_gpu=false
+            backend=:cpu
         )
 
         # Should detect only one peak (overlap removed)
@@ -105,7 +105,7 @@ using Test
             sigma_small=1.0,
             sigma_large=2.0,
             minval=0.1,
-            use_gpu=false
+            backend=:cpu
         )
 
         # Should detect two peaks
@@ -155,7 +155,7 @@ using Test
             sigma_small=1.0,
             sigma_large=2.0,
             minval=0.1,
-            use_gpu=false
+            backend=:cpu
         )
 
         # Should detect the peak
@@ -245,7 +245,7 @@ using Test
             psf_sigma = psf_sigma_microns,  # In microns (auto-converts to pixels)
             min_photons = 500.0,             # Should detect our 1000 photon peak
             boxsize = 11,
-            use_gpu = false
+            backend = :cpu
         )
 
         # Should detect the peak
@@ -266,7 +266,7 @@ using Test
             psf_sigma = psf_sigma_microns,
             min_photons = 5000.0,  # Way above our peak
             boxsize = 11,
-            use_gpu = false
+            backend = :cpu
         )
         @test length(roi_batch_high) == 0
     end
@@ -281,7 +281,7 @@ using Test
             sigma_small = 1.0,
             sigma_large = 2.0,
             minval = 0.1,
-            use_gpu = false
+            backend = :cpu
         )
 
         @test length(roi_batch) >= 1
@@ -355,7 +355,7 @@ using Test
             sigma_small=1.0,
             sigma_large=2.0,
             minval=0.5,  # Threshold to potentially reject noisy spot
-            use_gpu=false
+            backend=:cpu
         )
 
         # With variance weighting, the low-noise spot should be detected

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,7 @@ using Test
         # Test BoxesInfo structure
         @test info isa BoxesInfo
         @test info.backend == :cpu
-        @test info.elapsed_ns > 0
+        @test info.elapsed_s > 0
         @test info.device_id == -1  # CPU
 
         # Should detect two peaks
@@ -81,7 +81,7 @@ using Test
 
         # BoxesInfo should be valid
         @test info isa BoxesInfo
-        @test info.elapsed_ns > 0
+        @test info.elapsed_s > 0
     end
 
     @testset "New API with IdealCamera" begin
@@ -129,7 +129,7 @@ using Test
 
         # BoxesInfo should be valid
         @test info isa BoxesInfo
-        @test info.elapsed_ns > 0
+        @test info.elapsed_s > 0
     end
 
     @testset "New API with SCMOSCamera (scalar params)" begin
@@ -170,7 +170,7 @@ using Test
 
         # BoxesInfo should be valid
         @test info isa BoxesInfo
-        @test info.elapsed_ns > 0
+        @test info.elapsed_s > 0
     end
 
     @testset "Rectangular SCMOSCamera with per-pixel calibration" begin
@@ -259,7 +259,7 @@ using Test
 
         # BoxesInfo should be valid
         @test info isa BoxesInfo
-        @test info.elapsed_ns > 0
+        @test info.elapsed_s > 0
 
         # Test with higher threshold - should not detect
         (roi_batch_high, _) = getboxes(image, camera;
@@ -289,7 +289,7 @@ using Test
 
         # BoxesInfo should be valid
         @test info isa BoxesInfo
-        @test info.elapsed_ns > 0
+        @test info.elapsed_s > 0
     end
 
     @testset "sCMOS variance-weighted detection (per-pixel)" begin
@@ -335,7 +335,7 @@ using Test
 
         # BoxesInfo should be valid
         @test info isa BoxesInfo
-        @test info.elapsed_ns > 0
+        @test info.elapsed_s > 0
     end
 
 end

--- a/test/test_edge_corners.jl
+++ b/test/test_edge_corners.jl
@@ -45,7 +45,7 @@ roi_batch = getboxes(image, camera;
     minval = 10.0,
     boxsize = boxsize,
     overlap = 0.5,  # Tight to avoid merging
-    use_gpu = false
+    backend = :cpu
 )
 
 println("Detected $(length(roi_batch)) peaks (expected $(length(test_peaks)))")


### PR DESCRIPTION
## Summary

Major update adding ecosystem-aligned patterns and memory improvements:

- **Tuple-pattern return**: `getboxes()` now returns `(ROIBatch, BoxesInfo)` tuple
- **BoxerConfig struct**: Config-based calling convention alongside kwargs
- **CPU memory batching**: Memory-aware batching for CPU path (mirrors GPU)
- **Batch tracking**: `BoxesInfo` includes `n_rois`, `batch_size`, `n_batches`, `memory_per_batch`
- **Timing in seconds**: Changed `elapsed_ns` to `elapsed_s::Float64`
- **Refactored batching**: Extracted `_process_with_batching()` helper to deduplicate GPU/CPU paths

## Breaking Changes

- `getboxes()` returns `(ROIBatch, BoxesInfo)` instead of just `ROIBatch`
- `BoxesInfo.elapsed_ns` renamed to `BoxesInfo.elapsed_s` (now Float64 seconds)

## New Features

### BoxerConfig
```julia
config = BoxerConfig(psf_sigma=0.13, min_photons=500.0, boxsize=11)
(rois, info) = getboxes(data, camera, config)
```

### Two Calling Conventions
```julia
# Config-based (recommended for reusable settings)
(rois, info) = getboxes(data, camera, config)

# Kwargs-based (convenient for one-off calls)
(rois, info) = getboxes(data, camera; psf_sigma=0.13, min_photons=500.0)
```

### BoxesInfo with Batch Tracking
```julia
BoxesInfo(2 ROIs, 12.3 ms, cpu, 1 batches × 10, 234.4 KB/batch)
```

## Test Plan

- [x] All 80 unit tests pass
- [x] GPU tests pass on descent (92x-406x speedup)
- [x] Performance benchmarks pass
- [x] GPU wait/timeout tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)