### PR TITLE
ci: bump GitHub Actions to current majors for Node.js 24 deadline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,16 +26,16 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
   docs:
@@ -45,8 +45,8 @@ jobs:
       contents: write
       statuses: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - name: Configure doc environment


### PR DESCRIPTION
## Summary

GitHub is forcing all Actions runners to Node.js 24 on **2026-06-02**, and removing Node.js 20 entirely on **2026-09-16**. Several actions pinned in `CI.yml` were on majors that still ship Node 16/20 entrypoints and will break.

This PR bumps only the action versions — no behavior changes.

## Changes (`.github/workflows/CI.yml`)

- `actions/checkout@v3` → `@v4`
- `julia-actions/setup-julia@v1` → `@v2`
- `julia-actions/cache@v1` → `@v2`
- `codecov/codecov-action@v3` → `@v5`

Left at v1 (still the current major):
- `julia-actions/julia-buildpkg`, `julia-actions/julia-runtest`, `julia-actions/julia-processcoverage`, `julia-actions/julia-docdeploy`

`TagBot.yml` (`JuliaRegistries/TagBot@v1`) and `CompatHelper.yml` (no third-party actions) untouched.

## Test plan

- [ ] CI green on this PR (test matrix + docs job)
- [ ] Codecov upload still succeeds with v5